### PR TITLE
refactor: review Z80 implementation and make it zexall compliant

### DIFF
--- a/packages/kliveide-emu/src/native/api/memory-map.ts
+++ b/packages/kliveide-emu/src/native/api/memory-map.ts
@@ -5,9 +5,9 @@
 export const BANK_0_OFFS = 0x00_0000;
 export const ROM_48_OFFS = 0x02_0000;
 export const ROM_128_0_OFFS = 0x02_4000;
-export const REG_AREA_INDEX = 0x40_0A00;
-export const PAGE_INDEX_16 = 0x40_0A40;
-export const STATE_TRANSFER_BUFF = 0x40_0A80;
+export const REG_AREA_INDEX = 0x40_0B00;
+export const PAGE_INDEX_16 = 0x40_0B40;
+export const STATE_TRANSFER_BUFF = 0x40_0B80;
 export const TEST_INPUT_OFFS = 0x40_1000;
 export const TEST_MEM_LOG_OFFS = 0x40_1100;
 export const TEST_IO_LOG_OFFS = 0x40_1500;

--- a/packages/kliveide-emu/src/native/api/memory-map.ts
+++ b/packages/kliveide-emu/src/native/api/memory-map.ts
@@ -5,9 +5,9 @@
 export const BANK_0_OFFS = 0x00_0000;
 export const ROM_48_OFFS = 0x02_0000;
 export const ROM_128_0_OFFS = 0x02_4000;
-export const REG_AREA_INDEX = 0x40_0B00;
-export const PAGE_INDEX_16 = 0x40_0B40;
-export const STATE_TRANSFER_BUFF = 0x40_0B80;
+export const REG_AREA_INDEX = 0x40_0D00;
+export const PAGE_INDEX_16 = 0x40_0D40;
+export const STATE_TRANSFER_BUFF = 0x40_0D60;
 export const TEST_INPUT_OFFS = 0x40_1000;
 export const TEST_MEM_LOG_OFFS = 0x40_1100;
 export const TEST_IO_LOG_OFFS = 0x40_1500;

--- a/packages/kliveide-emu/src/native/memory-map.wat
+++ b/packages/kliveide-emu/src/native/memory-map.wat
@@ -42,36 +42,42 @@
 ;; SRA flags table (256 bytes)
 (global $SRA_FLAGS i32 (i32.const 0x40_0900))
 
+;; SZ53 flags table (256 bytes)
+(global $SZ53_FLAGS i32 (i32.const 0x40_0A00))
+
+;; SZ53P flags table (256 bytes)
+(global $SZ53P_FLAGS i32 (i32.const 0x40_0B00))
+
 ;; Overflow ADD table (8 bytes)
-(global $OVF_ADD i32 (i32.const 0x40_0A00))
+(global $OVF_ADD i32 (i32.const 0x40_0C00))
 
 ;; Overflow SUB table (8 bytes)
-(global $OVF_SUB i32 (i32.const 0x40_0A10))
+(global $OVF_SUB i32 (i32.const 0x40_0C10))
 
 ;; Half-carry ADD table (8 bytes)
-(global $HC_ADD i32 (i32.const 0x40_0A20))
+(global $HC_ADD i32 (i32.const 0x40_0C20))
 
 ;; Half-carry SUB table (8 bytes)
-(global $HC_SUB i32 (i32.const 0x40_0A30))
+(global $HC_SUB i32 (i32.const 0x40_0C30))
 
 ;; ----------------------------------------------------------------------------
 ;; Z80 CPU + State transfer area
 
 ;; Z80 registers (32 byte)
 ;; The index of the register area (length: 0x1c)
-(global $REG_AREA_INDEX i32 (i32.const 0x40_0B00))
+(global $REG_AREA_INDEX i32 (i32.const 0x40_0D00))
 
 ;; Z80 8-bit register index conversion table (8 bytes)
-(global $REG8_TAB_OFFS i32 (i32.const 0x40_0B20))
+(global $REG8_TAB_OFFS i32 (i32.const 0x40_0D20))
 
 ;; Z80 16-bit register index conversion table (4 bytes)
-(global $REG16_TAB_OFFS i32 (i32.const 0x40_0B30))
+(global $REG16_TAB_OFFS i32 (i32.const 0x40_0D30))
 
 ;; Page index table for addressing memory (24 bytes)
-(global $PAGE_INDEX_16 i32 (i32.const 0x40_0B40))
+(global $PAGE_INDEX_16 i32 (i32.const 0x40_0D40))
 
 ;; State transfer buffer between WA and JS (0x380 bytes)
-(global $STATE_TRANSFER_BUFF i32 (i32.const 0x40_0b80))
+(global $STATE_TRANSFER_BUFF i32 (i32.const 0x40_0D60))
 
 ;; ----------------------------------------------------------------------------
 ;; Z80 test machine buffers

--- a/packages/kliveide-emu/src/native/memory-map.wat
+++ b/packages/kliveide-emu/src/native/memory-map.wat
@@ -42,24 +42,36 @@
 ;; SRA flags table (256 bytes)
 (global $SRA_FLAGS i32 (i32.const 0x40_0900))
 
+;; Overflow ADD table (8 bytes)
+(global $OVF_ADD i32 (i32.const 0x40_0A00))
+
+;; Overflow SUB table (8 bytes)
+(global $OVF_SUB i32 (i32.const 0x40_0A10))
+
+;; Half-carry ADD table (8 bytes)
+(global $HC_ADD i32 (i32.const 0x40_0A20))
+
+;; Half-carry SUB table (8 bytes)
+(global $HC_SUB i32 (i32.const 0x40_0A30))
+
 ;; ----------------------------------------------------------------------------
 ;; Z80 CPU + State transfer area
 
 ;; Z80 registers (32 byte)
 ;; The index of the register area (length: 0x1c)
-(global $REG_AREA_INDEX i32 (i32.const 0x40_0A00))
+(global $REG_AREA_INDEX i32 (i32.const 0x40_0B00))
 
 ;; Z80 8-bit register index conversion table (8 bytes)
-(global $REG8_TAB_OFFS i32 (i32.const 0x40_0A20))
+(global $REG8_TAB_OFFS i32 (i32.const 0x40_0B20))
 
 ;; Z80 16-bit register index conversion table (4 bytes)
-(global $REG16_TAB_OFFS i32 (i32.const 0x40_0A30))
+(global $REG16_TAB_OFFS i32 (i32.const 0x40_0B30))
 
 ;; Page index table for addressing memory (24 bytes)
-(global $PAGE_INDEX_16 i32 (i32.const 0x40_0A40))
+(global $PAGE_INDEX_16 i32 (i32.const 0x40_0B40))
 
 ;; State transfer buffer between WA and JS (0x380 bytes)
-(global $STATE_TRANSFER_BUFF i32 (i32.const 0x40_0A80))
+(global $STATE_TRANSFER_BUFF i32 (i32.const 0x40_0b80))
 
 ;; ----------------------------------------------------------------------------
 ;; Z80 test machine buffers

--- a/packages/kliveide-emu/src/native/z80/z80-bit-ops.wat
+++ b/packages/kliveide-emu/src/native/z80/z80-bit-ops.wat
@@ -15,7 +15,8 @@
   i32.and
   set_local $res
   (i32.load8_u (i32.add (get_global $RLC_FLAGS) (get_local $a)))
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
   get_local $res
 )
 
@@ -30,7 +31,8 @@
   i32.and
   set_local $res
   (i32.load8_u (i32.add (get_global $RRC_FLAGS) (get_local $a)))
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
   get_local $res
 )
 
@@ -48,7 +50,8 @@
   get_local $a
   i32.add
   i32.load8_u
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
   (i32.shl (get_local $a) (i32.const 1))
   get_local $c
   i32.or
@@ -70,7 +73,8 @@
   get_local $a
   i32.add
   i32.load8_u
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
   (i32.shr_u (get_local $a) (i32.const 1))
   get_local $c
   i32.or
@@ -81,7 +85,8 @@
 (func $Sla (param $a i32) (result i32)
   (i32.add (get_global $RL0_FLAGS) (get_local $a))
   i32.load8_u
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
   (i32.shl (get_local $a) (i32.const 1))
 )
 
@@ -90,7 +95,8 @@
 (func $Sra (param $a i32) (result i32)
   (i32.add (get_global $SRA_FLAGS) (get_local $a))
   i32.load8_u
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 
   (i32.shr_u (get_local $a) (i32.const 1))
   (i32.and (get_local $a) (i32.const 0x80))
@@ -102,7 +108,8 @@
 (func $Sll (param $a i32) (result i32)
   (i32.add (get_global $RL1_FLAGS) (get_local $a))
   i32.load8_u
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 
   (i32.shl (get_local $a) (i32.const 1))
   i32.const 1
@@ -114,7 +121,8 @@
 (func $Srl (param $a i32) (result i32)
   (i32.add (get_global $RR0_FLAGS) (get_local $a))
   i32.load8_u
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 
   (i32.shr_u (get_local $a) (i32.const 1))
 )
@@ -148,7 +156,8 @@
   i32.const 0x10 ;; (Z|PV|S, C, R3|R5, H)
   i32.or
 
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; ----------------------------------------------------------------------------
@@ -222,14 +231,11 @@
   call $Bit
 
   ;; Correct R3 and R5 flags
-  (i32.and (call $getF) (i32.const 0xd7))   ;; Clear R3 and R5
-  (i32.and 
-    (i32.shr_u (call $getWZ) (i32.const 8)) ;; Get R3 and R5 from WZH
-    (i32.const 0x28)
-  )
+  (i32.and (call $getF) (i32.const 0xd7))  ;; Clear R3 and R5
+  (i32.and (call $getWH) (i32.const 0x28)) ;; Get R3 and R5 from WZH
   i32.or
-  call $setF
-
+  call $setQ
+  (call $setF (call $getQ))
   (i32.eq (get_global $useGateArrayContention) (i32.const 0))
   if
     (call $memoryDelay (call $getHL))

--- a/packages/kliveide-emu/src/native/z80/z80-bit-ops.wat
+++ b/packages/kliveide-emu/src/native/z80/z80-bit-ops.wat
@@ -130,7 +130,7 @@
   tee_local $val
 
   ;; Z and PV
-  if (result i32) ;; (Z|PV|S)
+  if (result i32) ;; (S|Z|PV)
     (i32.and (get_local $val) (i32.const 0x80))
   else
     i32.const 0x44
@@ -138,17 +138,16 @@
 
   ;; Keep C
   (i32.and (call $getF) (i32.const 0x01))
+  i32.or
 
   ;; Keep R3 and R5
   (i32.and (get_local $val) (i32.const 0x28)) ;; (Z|PV|S, C, R3|R5)
+  i32.or
 
   ;; Set H
   i32.const 0x10 ;; (Z|PV|S, C, R3|R5, H)
+  i32.or
 
-  ;; Merge flags
-  i32.or
-  i32.or
-  i32.or
   (call $setF (i32.and (i32.const 0xff)))
 )
 

--- a/packages/kliveide-emu/src/native/z80/z80-bit-ops.wat
+++ b/packages/kliveide-emu/src/native/z80/z80-bit-ops.wat
@@ -131,17 +131,18 @@
 
   ;; Z and PV
   if (result i32) ;; (Z|PV|S)
-    i32.const 0x80
-    i32.const 0x00
-    (i32.eq (get_local $n) (i32.const 7))
-    select
+    (i32.and (get_local $val) (i32.const 0x80))
   else
     i32.const 0x44
   end
 
   ;; Keep C
   (i32.and (call $getF) (i32.const 0x01))
+
+  ;; Keep R3 and R5
   (i32.and (get_local $val) (i32.const 0x28)) ;; (Z|PV|S, C, R3|R5)
+
+  ;; Set H
   i32.const 0x10 ;; (Z|PV|S, C, R3|R5, H)
 
   ;; Merge flags
@@ -220,6 +221,15 @@
     (i32.const 3)
   )
   call $Bit
+
+  ;; Correct R3 and R5 flags
+  (i32.and (call $getF) (i32.const 0xd7))   ;; Clear R3 and R5
+  (i32.and 
+    (i32.shr_u (call $getWZ) (i32.const 8)) ;; Get R3 and R5 from WZH
+    (i32.const 0x28)
+  )
+  i32.or
+  call $setF
 
   (i32.eq (get_global $useGateArrayContention) (i32.const 0))
   if

--- a/packages/kliveide-emu/src/native/z80/z80-extended-ops.wat
+++ b/packages/kliveide-emu/src/native/z80/z80-extended-ops.wat
@@ -167,7 +167,7 @@
   (i32.eq (get_global $allowExtendedSet) (i32.const 0))
   if return end    
 
-  (i32.add (call $getHL) (call $readAddrFromCode))
+  (i32.add (call $getHL) (call $readCode16))
   call $setHL
   (call $incTacts (i32.const 2))
 )
@@ -177,7 +177,7 @@
   (i32.eq (get_global $allowExtendedSet) (i32.const 0))
   if return end    
 
-  (i32.add (call $getDE) (call $readAddrFromCode))
+  (i32.add (call $getDE) (call $readCode16))
   call $setDE
   (call $incTacts (i32.const 2))
 )
@@ -187,7 +187,7 @@
   (i32.eq (get_global $allowExtendedSet) (i32.const 0))
   if return end    
 
-  (i32.add (call $getBC) (call $readAddrFromCode))
+  (i32.add (call $getBC) (call $readCode16))
   call $setBC
   (call $incTacts (i32.const 2))
 )
@@ -195,11 +195,11 @@
 ;; in b,(c) (0x40)
 (func $InBC
   (local $pval i32)
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
-  (call $readPort (call $getBC))
-  tee_local $pval
-  call $setB
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
+  
+  ;; Read and store port value
+  (call $setB (call $readPort (call $getBC)) (tee_local $pval))
   
   ;; Adjust flags
   (i32.add (get_global $LOG_FLAGS) (get_local $pval))
@@ -211,8 +211,8 @@
 
 ;; out (c),b (0x41)
 (func $OutCB
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
   (call $writePort (call $getBC) (call $getB))
 )
 
@@ -226,7 +226,7 @@
 ;; ld (NN),bc (0x43)
 (func $LdNNiBC
   (local $addr i32)
-  call $readAddrFromCode
+  call $readCode16
   (i32.add (tee_local $addr) (i32.const 1))
   call $setWZ
   get_local $addr
@@ -238,11 +238,11 @@
 ;; in c,(c) (0x48)
 (func $InCC
   (local $pval i32)
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
-  (call $readPort (call $getBC))
-  tee_local $pval
-  call $setC
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
+  
+  ;; Read and store port value
+  (call $setC (call $readPort (call $getBC)) (tee_local $pval))
   
   ;; Adjust flags
   (i32.add (get_global $LOG_FLAGS) (get_local $pval))
@@ -254,19 +254,19 @@
 
 ;; out (c),c (0x49)
 (func $OutCC
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
   (call $writePort (call $getBC) (call $getC))
 )
 
 ;; in d,(c) (0x50)
 (func $InDC
   (local $pval i32)
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
-  (call $readPort (call $getBC))
-  tee_local $pval
-  call $setD
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
+  
+  ;; Read and store port value
+  (call $setD (call $readPort (call $getBC)) (tee_local $pval))
   
   ;; Adjust flags
   (i32.add (get_global $LOG_FLAGS) (get_local $pval))
@@ -278,19 +278,19 @@
 
 ;; out (c),d (0x51)
 (func $OutCD
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
   (call $writePort (call $getBC) (call $getD))
 )
 
 ;; in e,(c) (0x58)
 (func $InEC
   (local $pval i32)
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
-  (call $readPort (call $getBC))
-  tee_local $pval
-  call $setE
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
+  
+  ;; Read and store port value
+  (call $setE (call $readPort (call $getBC)) (tee_local $pval))
   
   ;; Adjust flags
   (i32.add (get_global $LOG_FLAGS) (get_local $pval))
@@ -302,19 +302,20 @@
 
 ;; out (c),e (0x59)
 (func $OutCE
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
   (call $writePort (call $getBC) (call $getE))
 )
 
 ;; in h,(c) (0x60)
 (func $InHC
   (local $pval i32)
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
-  (call $readPort (call $getBC))
-  tee_local $pval
-  call $setH
+
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
+  
+  ;; Read and store port value
+  (call $setH (call $readPort (call $getBC)) (tee_local $pval))
   
   ;; Adjust flags
   (i32.add (get_global $LOG_FLAGS) (get_local $pval))
@@ -326,19 +327,20 @@
 
 ;; out (c),h (0x61)
 (func $OutCH
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
   (call $writePort (call $getBC) (call $getH))
 )
 
 ;; in l,(c) (0x68)
 (func $InLC
   (local $pval i32)
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
-  (call $readPort (call $getBC))
-  tee_local $pval
-  call $setL
+
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
+  
+  ;; Read and store port value
+  (call $setL (call $readPort (call $getBC)) (tee_local $pval))
   
   ;; Adjust flags
   (i32.add (get_global $LOG_FLAGS) (get_local $pval))
@@ -350,17 +352,19 @@
 
 ;; out (c),l (0x69)
 (func $OutCL
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
   (call $writePort (call $getBC) (call $getL))
 )
 
 ;; in (c) (0x70)
 (func $In0C
   (local $pval i32)
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
-  (call $readPort (call $getBC))
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
+  
+  ;; Read port value
+  (call $readPort (call $getBC)) 
   set_local $pval
   
   ;; Adjust flags
@@ -373,19 +377,19 @@
 
 ;; out (c),0 (0x71)
 (func $OutC0
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
   (call $writePort (call $getBC) (i32.const 0))
 )
 
 ;; in a,(c) (0x78)
 (func $InAC
   (local $pval i32)
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
-  (call $readPort (call $getBC))
-  tee_local $pval
-  call $setA
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
+  
+  ;; Read and store port value
+  (call $setA (call $readPort (call $getBC)) (tee_local $pval))
   
   ;; Adjust flags
   (i32.add (get_global $LOG_FLAGS) (get_local $pval))
@@ -397,8 +401,8 @@
 
 ;; out (c),a (0x79)
 (func $OutCA
-  (i32.add (call $getBC) (i32.const 1))
-  call $setWZ
+  ;; WZ = BC + 1
+  (call $setWZ (i32.add (call $getBC) (i32.const 1)))
   (call $writePort (call $getBC) (call $getA))
 )
 
@@ -408,7 +412,7 @@
   (local $addr i32)
 
   ;; Obtain address
-  call $readAddrFromCode
+  call $readCode16
   (i32.add (tee_local $addr) (i32.const 1))
   call $setWZ
 
@@ -534,7 +538,7 @@
 ;; ld bc,(NN) (0x4b)
 (func $LdBCNNi
   (local $addr i32)
-  call $readAddrFromCode
+  call $readCode16
   (call $setWZ (i32.add (tee_local $addr) (i32.const 1)))
   (call $setC (call $readMemory (get_local $addr)))
   (call $setB (call $readMemory (call $getWZ)))
@@ -557,7 +561,7 @@
 ;; ld (NN),de (0x53)
 (func $LdNNiDE
   (local $addr i32)
-  call $readAddrFromCode
+  call $readCode16
   (i32.add (tee_local $addr) (i32.const 1))
   call $setWZ
   get_local $addr
@@ -596,7 +600,8 @@
   i32.or
   i32.or
   i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
   (call $incTacts (i32.const 1))
 )
 
@@ -610,7 +615,7 @@
 ;; ld de,(NN) (0x5b)
 (func $LdDENNi
   (local $addr i32)
-  call $readAddrFromCode
+  call $readCode16
   (call $setWZ (i32.add (tee_local $addr) (i32.const 1)))
   (call $setE (call $readMemory (get_local $addr)))
   (call $setD (call $readMemory (call $getWZ)))
@@ -742,7 +747,7 @@
 ;; ld (NN),sp (0x73)
 (func $LdNNiSP
   (local $addr i32)
-  call $readAddrFromCode
+  call $readCode16
   (i32.add (tee_local $addr) (i32.const 1))
   call $setWZ
   get_local $addr
@@ -761,7 +766,7 @@
 ;; ld sp,(NN) (0x7b)
 (func $LdSPNNi
   (local $addr i32)
-  call $readAddrFromCode
+  call $readCode16
   (call $setWZ (i32.add (tee_local $addr) (i32.const 1)))
   (call $readMemory (get_local $addr))
   (call $readMemory (call $getWZ))
@@ -777,7 +782,7 @@
   (i32.eq (get_global $allowExtendedSet) (i32.const 0))
   if return end    
 
-  call $readAddrFromCode
+  call $readCode16
   set_local $v
   call $decSP
   get_global $SP
@@ -809,6 +814,9 @@
   ;; Increment HL
   (i32.add (get_local $hl) (i32.const 1))
   call $setHL
+
+  (i32.add (call $getBC) (i32.const 1))
+  call $setWZ
 )
 
 ;; nextreg (0x91)
@@ -949,7 +957,7 @@
   (local $de i32)
   (local $hl i32)
   (local $memVal i32)
-  
+
   ;; (DE) := (HL)
   call $getDE
   tee_local $de
@@ -1068,7 +1076,9 @@
   (local $hl i32)
   (call $incTacts (i32.const 1))
   call $getBC
-  (i32.add (tee_local $bc) (i32.const 1))
+
+  ;; Increment or decrement WZ
+  (i32.add (tee_local $bc) (get_local $step))
   call $setWZ
 
   ;; (HL) := in(BC)
@@ -1141,8 +1151,8 @@
   (i32.add (get_local $hl) (get_local $step))
   call $setHL
 
-  ;; WZ := BC + 1
-  (i32.add (get_local $b) (i32.const 1))
+  ;; WZ := BC +/- 1
+  (i32.add (get_local $b) (get_local $step))
   call $setWZ
 )
 
@@ -1208,7 +1218,8 @@
 )
 
 ;; Tail of the cpir/cpdr operations
-(func $CprTail
+(func $CprTail (param $step i32)
+
   (local $f i32)
   (local $pc i32)
   call $getBC
@@ -1234,6 +1245,11 @@
 
       ;; WZ := PC + 1
       (i32.add (get_local $pc) (i32.const 1))
+      call $setWZ
+
+    else
+      ;; WZ++/WZ--
+      (i32.add (call $getWZ) (get_local $step))
       call $setWZ
     end
   end
@@ -1323,9 +1339,11 @@
 
   ;; Merge flags
   i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 
-  call $getHL
+  ;; WZ++
+  (i32.add (call $getWZ) (i32.const 1))
   call $setWZ
 )
 
@@ -1404,7 +1422,7 @@
   ;; Merge flags
   i32.or
   (call $setF (i32.and (i32.const 0xff)))
-  call $getHL
+  (i32.sub (call $getWZ) (i32.const 1))
   call $setWZ
 )
 
@@ -1437,6 +1455,7 @@
 (func $Cpir
   (call $CpBase (i32.const 1))
   (call $setF (i32.and (i32.const 0xff)))
+  i32.const 1
   call $CprTail
 )
 
@@ -1507,6 +1526,7 @@
 (func $Cpdr
   (call $CpBase (i32.const -1))
   (call $setF (i32.and (i32.const 0xff)))
+  i32.const -1
   call $CprTail
 )
 

--- a/packages/kliveide-emu/src/native/z80/z80-indexed-bit-ops.wat
+++ b/packages/kliveide-emu/src/native/z80/z80-indexed-bit-ops.wat
@@ -52,6 +52,15 @@
   )
   call $Bit
 
+  ;; Correct the R3 and R5 flags
+  (i32.and (call $getF) (i32.const 0xd7)) ;; Mask out R3 and R5
+  (i32.and
+    (i32.shr_u (get_local $addr) (i32.const 8))
+    (i32.const 0x28)
+  )
+  i32.or
+  call $setF
+
   (i32.eq (get_global $useGateArrayContention) (i32.const 0))
   if
     (call $memoryDelay (call $getHL))

--- a/packages/kliveide-emu/src/native/z80/z80-standard-ops.wat
+++ b/packages/kliveide-emu/src/native/z80/z80-standard-ops.wat
@@ -89,9 +89,11 @@
   get_local $res
   i32.or
   (call $setA (i32.and (i32.const 0xff)))
-  call $getF
-  i32.const 0xc4 ;; S, Z, PV flags mask
-  i32.and
+  (i32.and (call $getF) (i32.const 0xc4))      ;; S, Z, PV flags mask
+  (i32.and (get_local $res) (i32.const 0x28)) ;; R3 and R5 from result
+  i32.or
+
+  ;; Combine Carry into the result
   get_local $newC
   i32.or
   (call $setF (i32.and (i32.const 0xff)))
@@ -174,16 +176,15 @@
   (i32.shr_u (call $getA) (i32.const 1))
 
   ;; Combine with C flag
-  get_local $newC
-  i32.const 7
-  i32.shl
+  (i32.shl (get_local $newC) (i32.const 7))
   i32.or
   (call $setA (i32.and (i32.const 0xff)))
 
   ;; Calc the new F
-  call $getF
-  i32.const 0xC4 ;; Keep S, Z, PV
-  i32.and
+  (i32.and (call $getF) (i32.const 0xc4)) ;; Keep S, Z, PV
+  (i32.and (call $getA) (i32.const 0x28)) ;; Keey R3 and R5
+  i32.or
+  
   get_local $newC
   i32.or
   (call $setF (i32.and (i32.const 0xff)))
@@ -271,9 +272,10 @@
   (call $setA (i32.and (i32.const 0xff)))
 
   ;; Calculate new C Flag
-  call $getF
-  i32.const 0xc4 ;; Keep S, Z, PV
-  i32.and
+  (i32.and (call $getF) (i32.const 0xc4)) ;; Keep S, Z, PV
+  (i32.and (call $getA) (i32.const 0x28)) ;; Keep R3 and R5
+  i32.or
+
   get_local $newC
   i32.or
   (call $setF (i32.and (i32.const 0xff)))
@@ -358,9 +360,10 @@
   (call $setA (i32.and (i32.const 0xff)))
 
   ;; Calculate new C Flag
-  call $getF
-  i32.const 0xc4 ;; Keep S, Z, PV
-  i32.and
+  (i32.and (call $getF) (i32.const 0xc4)) ;; Keep S, Z, PV
+  (i32.and (call $getA) (i32.const 0x28)) ;; Keep R3 and R5
+  i32.or
+
   get_local $newC
   i32.or
   (call $setF (i32.and (i32.const 0xff)))
@@ -745,9 +748,10 @@
   (call $setA (i32.and (i32.const 0xff)))
 
   ;; New F
-  call $getF
-  i32.const 0xed ;; Keep S, Z, R3, R3, PV, C
-  i32.and
+  (i32.and (call $getF) (i32.const 0xc5)) ;; Keep S, Z, PV, C
+  (i32.and (call $getA) (i32.const 0x28)) ;; Keep R3 and R5
+  i32.or
+  
   i32.const 0x12 ;; Set H and N
   i32.or
   (call $setF (i32.and (i32.const 0xff)))
@@ -958,12 +962,18 @@
 
 ;; ccf (0x3f)
 (func $Ccf
+  (local $cFlag i32)
   (i32.and (call $getA) (i32.const 0x28)) ;; Mask for R5, R3
   (i32.and (call $getF) (i32.const 0xc4)) ;; Mask for S, Z, PV
   i32.or
+  
   (i32.and (call $getF) (i32.const 0x01)) ;; Mask for C flag
+  tee_local $cFlag
   i32.const 0x01 ;; Complement C flag
   i32.xor
+  i32.or
+
+  (i32.shl (get_local $cFlag) (i32.const 4)) ;; Set H to the previous C
   i32.or
   (call $setF (i32.and (i32.const 0xff)))
 )

--- a/packages/kliveide-emu/src/native/z80/z80-standard-ops.wat
+++ b/packages/kliveide-emu/src/native/z80/z80-standard-ops.wat
@@ -3,12 +3,16 @@
 
 ;; ld bc,NN (0x01)
 (func $LdBCNN
-  (call $setBC (call $readAddrFromCode))
+  (call $setBC (call $readCode16))
 )
 
 ;; ld (bc),a (0x02)
 (func $LdBCiA
   (call $writeMemory (call $getBC) (call $getA))
+
+  ;; Update WZ
+  (call $setWL (call $getA))
+  (call $setWH (i32.add (call $getBC) (i32.const 1)))
 )
 
 ;; inc bc (0x03)
@@ -17,39 +21,19 @@
   (call $incTacts (i32.const 2))
 )
 
-;; Adjust INC flags
-(func $adjustIncFlags (param $v i32)
-  (i32.add (get_global $INC_FLAGS) (get_local $v))
-  i32.load8_u
-  (i32.and (call $getF) (i32.const 0x01)) ;; C flag mask
-  i32.or
-  (call $setF (i32.and (i32.const 0xff)))
-)
-
 ;; inc b (0x04)
 (func $IncB
   (local $v i32)
   call $getB
-  (i32.add (tee_local $v) (i32.const 1))
-  call $setB
+  (call $setB (i32.add (tee_local $v) (i32.const 1)))
   (call $adjustIncFlags (get_local $v))
-)
-
-;; Adjust DEC flags
-(func $adjustDecFlags (param $v i32)
-  (i32.add (get_global $DEC_FLAGS) (get_local $v))
-  i32.load8_u
-  (i32.and (call $getF) (i32.const 0x01)) ;; C flag mask
-  i32.or
-  (call $setF (i32.and (i32.const 0xff)))
 )
 
 ;; dec b (0x05)
 (func $DecB
   (local $v i32)
   call $getB
-  (i32.sub (tee_local $v) (i32.const 1))
-  call $setB
+  (call $setB (i32.sub (tee_local $v) (i32.const 1)))
   (call $adjustDecFlags (get_local $v))
 )
 
@@ -58,70 +42,35 @@
   (call $setB (call $readCodeMemory))
 )
 
-;; ld Q,N (0x06, 0x0e, 0x16, 0x1e, 0x26, 0x2e, 0x36, 0x3e)
-(func $LdQN
-  (local $q i32)
-
-  ;; Get 8-bit reg index
-  (i32.shr_u 
-    (i32.and (get_global $opCode) (i32.const 0x38))
-    (i32.const 3)
-  )
-
-  ;; Fetch data and store it
-  call $readCodeMemory
-  call $setReg8
-)
-
 ;; rlca (0x07)
 (func $Rlca
-  (local $res i32)
-  (local $newC i32)
-  (i32.shl (call $getA) (i32.const 1))
-  
-  (i32.ge_u (tee_local $res) (i32.const 0x100))
-  if (result i32)
-    i32.const 0x01
-  else
-    i32.const 0x00
-  end
-  tee_local $newC
-  get_local $res
-  i32.or
-  (call $setA (i32.and (i32.const 0xff)))
-  (i32.and (call $getF) (i32.const 0xc4))      ;; S, Z, PV flags mask
-  (i32.and (get_local $res) (i32.const 0x28)) ;; R3 and R5 from result
-  i32.or
-
-  ;; Combine Carry into the result
-  get_local $newC
-  i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (i32.or
+    (i32.shl (call $getA) (i32.const 1))
+    (i32.shr_u (call $getA) (i32.const 7))
+  )
+  call $setA
+  (i32.or
+    ;; S, Z, PV flags mask
+    (i32.and (call $getF) (i32.const 0xc4))
+    ;; R5, R3, C from result 
+    (i32.and (call $getA) (i32.const 0x29)) 
+  )
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; ex af,af' (0x08)
 (func $ExAf
   (local $tmp i32)
-  call $getAF
-  set_local $tmp
-  get_global $REG_AREA_INDEX
-  i32.load16_u offset=8
-  call $setAF
-  get_global $REG_AREA_INDEX
-  get_local $tmp
-  i32.store16 offset=8
+  (set_local $tmp (call $getAF))
+  (call $setAF (i32.load16_u offset=8 (get_global $REG_AREA_INDEX)))
+  (i32.store16 offset=8 (get_global $REG_AREA_INDEX) (get_local $tmp))
 )
 
 ;; add hl,bc (0x09)
 (func $AddHLBC
-  ;; Calculate WZ
-  (i32.add (call $getHL) (i32.const 1))
-  call $setWZ
-
-  ;; Calc the new HL value
-  (call $AluAddHL (call $getHL) (call $getBC))
+  (call $AluAdd16 (call $getHL) (call $getBC))
   call $setHL
-  (call $incTacts (i32.const 7))
 )
 
 ;; ld a,(bc) (0x0a)
@@ -131,8 +80,7 @@
   call $setWZ
 
   ;; Read A from (BC)
-  call $getBC
-  call $readMemory
+  (call $readMemory (call $getBC))
   (call $setA (i32.and (i32.const 0xff)))
 )
 
@@ -146,8 +94,7 @@
 (func $IncC
   (local $v i32)
   call $getC
-  (i32.add (tee_local $v) (i32.const 1))
-  call $setC
+  (call $setC (i32.add (tee_local $v) (i32.const 1)))
   (call $adjustIncFlags (get_local $v))
 )
 
@@ -155,8 +102,7 @@
 (func $DecC
   (local $v i32)
   call $getC
-  (i32.sub (tee_local $v) (i32.const 1))
-  call $setC
+  (call $setC (i32.sub (tee_local $v) (i32.const 1)))
   (call $adjustDecFlags (get_local $v))
 )
 
@@ -181,21 +127,21 @@
   (call $setA (i32.and (i32.const 0xff)))
 
   ;; Calc the new F
-  (i32.and (call $getF) (i32.const 0xc4)) ;; Keep S, Z, PV
-  (i32.and (call $getA) (i32.const 0x28)) ;; Keey R3 and R5
-  i32.or
+  (i32.or
+    (i32.and (call $getF) (i32.const 0xc4)) ;; Keep S, Z, PV
+    (i32.and (call $getA) (i32.const 0x28)) ;; Keey R3 and R5
+  )
+  (i32.or (get_local $newC))
   
-  get_local $newC
-  i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; djnz (0x10)
 (func $Djnz
   (local $e i32)
   (call $incTacts (i32.const 1))
-  call $readCodeMemory
-  set_local $e
+  (set_local $e (call $readCodeMemory))
 
   ;; Decrement B
   (i32.sub (call $getB) (i32.const 1))
@@ -211,11 +157,14 @@
 
 ;; ld de,NN (0x11)
 (func $LdDENN
-  (call $setDE (call $readAddrFromCode))
+  (call $setDE (call $readCode16))
 )
 
 ;; ld (de),a (0x12)
 (func $LdDEiA
+  ;; Update WZ
+  (call $setWH (i32.add (call $getDE) (i32.const 1)))
+  (call $setWL (call $getA))
   (call $writeMemory (call $getDE) (call $getA))
 )
 
@@ -229,8 +178,7 @@
 (func $IncD
   (local $v i32)
   call $getD
-  (i32.add (tee_local $v) (i32.const 1))
-  call $setD
+  (call $setD (i32.add (tee_local $v) (i32.const 1)))
   (call $adjustIncFlags (get_local $v))
 )
 
@@ -238,8 +186,7 @@
 (func $DecD
   (local $v i32)
   call $getD
-  (i32.sub (tee_local $v) (i32.const 1))
-  call $setD
+  (call $setD (i32.sub (tee_local $v) (i32.const 1)))
   (call $adjustDecFlags (get_local $v))
 )
 
@@ -278,7 +225,8 @@
 
   get_local $newC
   i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; jr NN (0x18)
@@ -288,14 +236,8 @@
 
 ;; add hl,de (0x19)
 (func $AddHLDE
-  ;; Calculate WZ
-  (i32.add (call $getHL) (i32.const 1))
-  call $setWZ
-
-  ;; Calc the new HL value
-  (call $AluAddHL (call $getHL) (call $getDE))
+  (call $AluAdd16 (call $getHL) (call $getDE))
   call $setHL
-  (call $incTacts (i32.const 7))
 )
 
 ;; ld a,(de) (0x1a)
@@ -320,8 +262,7 @@
 (func $IncE
   (local $v i32)
   call $getE
-  (i32.add (tee_local $v) (i32.const 1))
-  call $setE
+  (call $setE (i32.add (tee_local $v) (i32.const 1)))
   (call $adjustIncFlags (get_local $v))
 )
 
@@ -329,8 +270,7 @@
 (func $DecE
   (local $v i32)
   call $getE
-  (i32.sub (tee_local $v) (i32.const 1))
-  call $setE
+  (call $setE (i32.sub (tee_local $v) (i32.const 1)))
   (call $adjustDecFlags (get_local $v))
 )
 
@@ -366,46 +306,36 @@
 
   get_local $newC
   i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; jr nz,NN (0x20)
 (func $JrNz
   (local $e i32)
-  call $readCodeMemory
-  set_local $e
+  (set_local $e (call $readCodeMemory))
   call $testZ
   if return end
-
-  ;; Jump
-  get_local $e
-  call $relativeJump
+  (call $relativeJump (get_local $e))
 )
 
 ;; ld hl,NN (0x21)
 (func $LdHLNN
-  (call $setHL (call $readAddrFromCode))
+  (call $setHL (call $readCode16))
 )
 
-;; ld (NN),hl
+;; ld (NN),hl (0x22)
 (func $LdNNiHL
   (local $addr i32)
   ;; Obtain the address to store HL
-  call $readAddrFromCode
-  tee_local $addr
+  (tee_local $addr (call $readCode16))
 
   ;; Set WZ to addr + 1
-  i32.const 1
-  i32.add
-  call $setWZ
+  (call $setWZ (i32.add (i32.const 1)))
 
   ;; Store HL
-  get_local $addr
-  call $getL
-  call $writeMemory
-  call $getWZ
-  call $getH
-  call $writeMemory
+  (call $writeMemory (get_local $addr) (call $getL))
+  (call $writeMemory (call $getWZ) (call $getH))
 )
 
 ;; inc hl (0x23)
@@ -418,8 +348,7 @@
 (func $IncH
   (local $v i32)
   call $getH
-  (i32.add (tee_local $v) (i32.const 1))
-  call $setH
+  (call $setH (i32.add (tee_local $v) (i32.const 1)))
   (call $adjustIncFlags (get_local $v))
 )
 
@@ -427,8 +356,7 @@
 (func $DecH
   (local $v i32)
   call $getH
-  (i32.sub (tee_local $v) (i32.const 1))
-  call $setH
+  (call $setH (i32.sub (tee_local $v) (i32.const 1)))
   (call $adjustDecFlags (get_local $v))
 )
 
@@ -663,53 +591,37 @@
   i32.or
 
   ;; Done
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; jr z,NN (0x28)
 (func $JrZ
   (local $e i32)
-  call $readCodeMemory
-  set_local $e
+  (set_local $e (call $readCodeMemory))
   call $testNZ
   if return end
-
-  ;; Jump
-  get_local $e
-  call $relativeJump
+  (call $relativeJump (get_local $e))
 )
 
 ;; add hl,hl (0x29)
 (func $AddHLHL
-  ;; Calculate WZ
-  (i32.add (call $getHL) (i32.const 1))
-  call $setWZ
-
-  ;; Calc the new HL value
-  (call $AluAddHL (call $getHL) (call $getHL))
+  (call $AluAdd16 (call $getHL) (call $getHL))
   call $setHL
-  (call $incTacts (i32.const 7))
 )
 
 ;; ld hl,(NN) (0x2a)
 (func $LdHLNNi
   (local $addr i32)
   ;; Read the address
-  call $readAddrFromCode
-  tee_local $addr
+  (tee_local $addr (call $readCode16))
 
   ;; Set WZ to addr + 1
-  i32.const 1
-  i32.add
-  call $setWZ
+  (call $setWZ (i32.add (i32.const 1)))
 
   ;; Read HL from memory
-  get_local $addr
-  call $readMemory
-  call $setL
-  call $getWZ
-  call $readMemory
-  call $setH
+  (call $setL (call $readMemory (get_local $addr)))
+  (call $setH (call $readMemory (call $getWZ)))
 )
 
 ;; dec hl (0x2b)
@@ -722,8 +634,7 @@
 (func $IncL
   (local $v i32)
   call $getL
-  (i32.add (tee_local $v) (i32.const 1))
-  call $setL
+  (call $setL (i32.add (tee_local $v) (i32.const 1)))
   (call $adjustIncFlags (get_local $v))
 )
 
@@ -731,8 +642,7 @@
 (func $DecL
   (local $v i32)
   call $getL
-  (i32.sub (tee_local $v) (i32.const 1))
-  call $setL
+  (call $setL (i32.sub (tee_local $v) (i32.const 1)))
   (call $adjustDecFlags (get_local $v))
 )
 
@@ -754,46 +664,35 @@
   
   i32.const 0x12 ;; Set H and N
   i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; jr nc,NN (0x30)
 (func $JrNc
   (local $e i32)
-  call $readCodeMemory
-  set_local $e
+  (set_local $e (call $readCodeMemory))
   call $testC
   if return end
-
-  ;; Jump
-  get_local $e
-  call $relativeJump
+  (call $relativeJump (get_local $e))
 )
 
 ;; ld sp,NN (0x31)
 (func $LdSPNN
-  (call $setSP (call $readAddrFromCode))
+  (call $setSP (call $readCode16))
 )
 
 ;; ld (NN),a (0x32)
 (func $LdNNiA
   (local $addr i32)
+  (tee_local $addr (call $readCode16))
 
-  ;; Read the address
-  call $readAddrFromCode
-  tee_local $addr
-
-  ;; Set WZ to addr + 1
-  i32.const 1
-  i32.add
-  call $setWZ
+  ;; Adjust WZ
+  (call $setWL (i32.add (i32.const 1)))
+  (call $setWH (call $getA))
 
   ;; Store A
-  get_local $addr
-  call $getA
-  call $writeMemory
-  call $getA
-  call $setWH
+  (call $writeMemory (get_local $addr) (call $getA))
 )
 
 ;; inc sp (0x33)
@@ -809,15 +708,13 @@
   (local $v i32)
 
   ;; Get the value from the memory
-  call $getHL
-  call $readMemory
+  (call $readMemory (call $getHL))
   set_local $v
 
   ;; Adjust tacts
   (i32.eq (get_global $useGateArrayContention) (i32.const 0))
   if
-    call $getHL
-    call $memoryDelay
+    (call $memoryDelay (call $getHL))
   end
   (call $incTacts (i32.const 1))
 
@@ -834,7 +731,8 @@
   i32.const 0x01 ;; C flag mask
   i32.and
   i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; dec (hl) (0x35)
@@ -842,8 +740,7 @@
   (local $v i32)
 
   ;; Get the value from the memory
-  call $getHL
-  call $readMemory
+  (call $readMemory (call $getHL))
   set_local $v
 
   ;; Adjust tacts
@@ -867,14 +764,13 @@
   i32.const 0x01 ;; C flag mask
   i32.and
   i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; ld (hl),n (0x36)
 (func $LdHLiN
-  call $getHL
-  call $readCodeMemory
-  call $writeMemory
+  (call $writeMemory (call $readCodeMemory (call $getHL)))
 )
 
 ;; scf (0x37)
@@ -884,32 +780,23 @@
   i32.or
   i32.const 0x01 ;; Mask for C flag
   i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; jr c,NN (0x38)
 (func $JrC
   (local $e i32)
-  call $readCodeMemory
-  set_local $e
+  (set_local $e (call $readCodeMemory))
   call $testNC
   if return end
-
-  ;; Jump
-  get_local $e
-  call $relativeJump
+  (call $relativeJump (get_local $e))
 )
 
 ;; add hl,sp (0x39)
 (func $AddHLSP
-  ;; Calculate WZ
-  (i32.add (call $getHL) (i32.const 1))
-  call $setWZ
-
-  ;; Calc the new HL value
-  (call $AluAddHL (call $getHL) (get_global $SP))
+  (call $AluAdd16 (call $getHL) (get_global $SP))
   call $setHL
-  (call $incTacts (i32.const 7))
 )
 
 ;; ld a,(NN) (0x3a)
@@ -917,17 +804,13 @@
   (local $addr i32)
 
   ;; Read the address
-  call $readAddrFromCode
-  tee_local $addr
-
+  (tee_local $addr (call $readCode16))
+  
   ;; Set WZ to addr + 1
-  i32.const 1
-  i32.add
-  call $setWZ
-
+  (call $setWZ (i32.const 1) (i32.add))
+  
   ;; Read A from memory
-  get_local $addr
-  call $readMemory
+  (call $readMemory (get_local $addr))
   (call $setA (i32.and (i32.const 0xff)))
 )
 
@@ -941,8 +824,7 @@
 (func $IncA
   (local $v i32)
   call $getA
-  (i32.add (tee_local $v) (i32.const 1))
-  call $setA
+  (call $setA (i32.add (tee_local $v) (i32.const 1)))
   (call $adjustIncFlags (get_local $v))
 )
 
@@ -950,8 +832,7 @@
 (func $DecA
   (local $v i32)
   call $getA
-  (i32.sub (tee_local $v) (i32.const 1))
-  call $setA
+  (call $setA (i32.sub (tee_local $v) (i32.const 1)))
   (call $adjustDecFlags (get_local $v))
 )
 
@@ -975,7 +856,8 @@
 
   (i32.shl (get_local $cFlag) (i32.const 4)) ;; Set H to the previous C
   i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; ld b,c (0x41)
@@ -1858,8 +1740,10 @@
   tee_local $port
   call $getA
   call $writePort
-  (i32.add (get_local $port) (i32.const 1))
-  call $setWZ
+
+  ;; Update WZ
+  (call $setWL (i32.add (get_local $port) (i32.const 1)))
+  (call $setWH (call $getA))
 )
 
 ;; call nc (0xd4)

--- a/packages/kliveide-emu/src/native/z80/z80.wat
+++ b/packages/kliveide-emu/src/native/z80/z80.wat
@@ -134,29 +134,32 @@
 ;; SRA flags table
 (data (i32.const 0x40_0900) "\44\45\00\01\00\01\04\05\00\01\04\05\04\05\00\01\08\09\0c\0d\0c\0d\08\09\0c\0d\08\09\08\09\0c\0d\00\01\04\05\04\05\00\01\04\05\00\01\00\01\04\05\0c\0d\08\09\08\09\0c\0d\08\09\0c\0d\0c\0d\08\09\20\21\24\25\24\25\20\21\24\25\20\21\20\21\24\25\2c\2d\28\29\28\29\2c\2d\28\29\2c\2d\2c\2d\28\29\24\25\20\21\20\21\24\25\20\21\24\25\24\25\20\21\28\29\2c\2d\2c\2d\28\29\2c\2d\28\29\28\29\2c\2d\84\85\80\81\80\81\84\85\80\81\84\85\84\85\80\81\88\89\8c\8d\8c\8d\88\89\8c\8d\88\89\88\89\8c\8d\80\81\84\85\84\85\80\81\84\85\80\81\80\81\84\85\8c\8d\88\89\88\89\8c\8d\88\89\8c\8d\8c\8d\88\89\a0\a1\a4\a5\a4\a5\a0\a1\a4\a5\a0\a1\a0\a1\a4\a5\ac\ad\a8\a9\a8\a9\ac\ad\a8\a9\ac\ad\ac\ad\a8\a9\a4\a5\a0\a1\a0\a1\a4\a5\a0\a1\a4\a5\a4\a5\a0\a1\a8\a9\ac\ad\ac\ad\a8\a9\ac\ad\a8\a9\a8\a9\ac\ad")
 
+;; SZ53 flags table (256 bytes)
+(data (i32.const 0x40_0A00) "\40\00\00\00\00\00\00\00\08\08\08\08\08\08\08\08\00\00\00\00\00\00\00\00\08\08\08\08\08\08\08\08\20\20\20\20\20\20\20\20\28\28\28\28\28\28\28\28\20\20\20\20\20\20\20\20\28\28\28\28\28\28\28\28\00\00\00\00\00\00\00\00\08\08\08\08\08\08\08\08\00\00\00\00\00\00\00\00\08\08\08\08\08\08\08\08\20\20\20\20\20\20\20\20\28\28\28\28\28\28\28\28\20\20\20\20\20\20\20\20\28\28\28\28\28\28\28\28\80\80\80\80\80\80\80\80\88\88\88\88\88\88\88\88\80\80\80\80\80\80\80\80\88\88\88\88\88\88\88\88\a0\a0\a0\a0\a0\a0\a0\a0\a8\a8\a8\a8\a8\a8\a8\a8\a0\a0\a0\a0\a0\a0\a0\a0\a8\a8\a8\a8\a8\a8\a8\a8\80\80\80\80\80\80\80\80\88\88\88\88\88\88\88\88\80\80\80\80\80\80\80\80\88\88\88\88\88\88\88\88\a0\a0\a0\a0\a0\a0\a0\a0\a8\a8\a8\a8\a8\a8\a8\a8\a0\a0\a0\a0\a0\a0\a0\a0\a8\a8\a8\a8\a8\a8\a8\a8")
+
+;; SZ53P flags table (256 bytes)
+(data (i32.const 0x40_0B00) "\44\00\00\04\00\04\04\00\08\0c\0c\08\0c\08\08\0c\00\04\04\00\04\00\00\04\0c\08\08\0c\08\0c\0c\08\20\24\24\20\24\20\20\24\2c\28\28\2c\28\2c\2c\28\24\20\20\24\20\24\24\20\28\2c\2c\28\2c\28\28\2c\00\04\04\00\04\00\00\04\0c\08\08\0c\08\0c\0c\08\04\00\00\04\00\04\04\00\08\0c\0c\08\0c\08\08\0c\24\20\20\24\20\24\24\20\28\2c\2c\28\2c\28\28\2c\20\24\24\20\24\20\20\24\2c\28\28\2c\28\2c\2c\28\80\84\84\80\84\80\80\84\8c\88\88\8c\88\8c\8c\88\84\80\80\84\80\84\84\80\88\8c\8c\88\8c\88\88\8c\a4\a0\a0\a4\a0\a4\a4\a0\a8\ac\ac\a8\ac\a8\a8\ac\a0\a4\a4\a0\a4\a0\a0\a4\ac\a8\a8\ac\a8\ac\ac\a8\84\80\80\84\80\84\84\80\88\8c\8c\88\8c\88\88\8c\80\84\84\80\84\80\80\84\8c\88\88\8c\88\8c\8c\88\a0\a4\a4\a0\a4\a0\a0\a4\ac\a8\a8\ac\a8\ac\ac\a8\a4\a0\a0\a4\a0\a4\a4\a0\a8\ac\ac\a8\ac\a8\a8\ac")
+
+;; Overflow ADD table (8 bytes)
+(data (i32.const 0x40_0C00) "\00\00\00\04\04\00\00\00")
+
+;; Overflow SUB table (8 bytes)
+(data (i32.const 0x40_0C10) "\00\04\00\00\00\00\04\00")
+
+;; Half-carry ADD table (8 bytes)
+(data (i32.const 0x40_0C20) "\00\10\10\10\00\00\00\10")
+
+;; Half-carry SUB table (8 bytes)
+(data (i32.const 0x40_0C30) "\00\00\10\00\10\00\10\10")
+
 ;; ----------------------------------------------------------------------------
 ;; Register index conversion tables
 
 ;; Z80 8-bit register index conversion table
-(data (i32.const 0x40_0B20) "\03\02\05\04\07\06\00\01")
+(data (i32.const 0x40_0D20) "\03\02\05\04\07\06\00\01")
 
 ;; Z80 16-bit register index conversion table
-(data (i32.const 0x40_0B30) "\02\04\06\14")
-
-;; ----------------------------------------------------------------------------
-;; Flag conversion tables
-
-;; Overflow ADD table (8 bytes)
-(data (i32.const 0x40_0A00) "\00\00\00\04\04\00\00\00")
-
-;; Overflow SUB table (8 bytes)
-(data (i32.const 0x40_0A10) "\00\04\00\00\00\00\04\00")
-
-;; Half-carry ADD table (8 bytes)
-(data (i32.const 0x40_0A20) "\00\10\10\10\00\00\00\10")
-
-;; Half-carry SUB table (8 bytes)
-(data (i32.const 0x40_0A30) "\00\00\10\00\10\00\10\10")
+(data (i32.const 0x40_0D30) "\02\04\06\14")
 
 ;; Writes the CPU state to the transfer area so that the JavaScript code
 ;; can read it. This method copies only the registers that are stored in global
@@ -962,8 +965,6 @@
   (call $setF (call $getQ))
 )
 
-
-
 ;; Decrements the value of SP
 (func $decSP
   (set_global $SP 
@@ -1304,88 +1305,97 @@
   i32.add
 )
 
+;; Gets the entry from the SZ53_FLAGS table
+(func $getSZ53 (param $arg i32) (result i32)
+  (i32.add
+    (get_global $SZ53_FLAGS)
+    (i32.and (get_local $arg) (i32.const 0xff))
+  )
+  i32.load8_u
+)
+
+;; Gets the entry from the SZ53_FLAGS table
+(func $getSZ53P (param $arg i32) (result i32)
+  (i32.add
+    (get_global $SZ53P_FLAGS)
+    (i32.and (get_local $arg) (i32.const 0xff))
+  )
+  i32.load8_u
+)
+
+;; Gets the r12 lookup value for flags
+(func $getR12Lookup
+  (param $r i32)
+  (param $1 i32)
+  (param $2 i32)
+  (result i32)
+  (i32.shr_u 
+    (i32.and (get_local $1) (i32.const 0x88))
+    (i32.const 3)
+  )
+  (i32.shr_u 
+    (i32.and (get_local $2) (i32.const 0x88))
+    (i32.const 2)
+  )
+  (i32.shr_u 
+    (i32.and (get_local $r) (i32.const 0x88))
+    (i32.const 1)
+  )
+  i32.or
+  i32.or
+)
+
 ;; Executes ALU addition; sets A and F
 ;; $arg: other argument
 ;; $c: Value of the C flag
 (func $AluAdd (param $arg i32) (param $c i32)
   (local $a i32)
   (local $res i32)
-  (local $pv i32)
+  (local $r12 i32)
+
   ;; Add values (+carry) and store in A
-  call $getA
-  tee_local $a
-  get_local $arg
-  i32.add
-  get_local $c
-  i32.add
+  (tee_local $a (call $getA))
+  (i32.add (get_local $arg))
+  (i32.add (get_local $c))
   tee_local $res
   (call $setA (i32.and (i32.const 0xff)))
 
-  ;; Put Z on stack
-  i32.const 0x00 ;; NZ
-  i32.const 0x40 ;; Z
-  (i32.and (get_local $res) (i32.const 0xff))
-  select         ;; Z
-
-  ;; Get S, R5, and R3 from result
-  get_local $res
-  i32.const 0xa8
-  i32.and        ;; Z, S|R5|R3
-
   ;; Get C flag
-  get_local $res
-  i32.const 0x100
-  i32.and
-  i32.const 8
-  i32.shr_u      ;; Z, S|R5|R3, C
-
-  ;; Calculate H flag
-  i32.const 0x10
-  i32.const 0x00
-  (i32.and (get_local $a) (i32.const 0x0f))
-  (i32.and (get_local $arg) (i32.const 0x0f))
-  i32.add
-  get_local $c
-  (i32.and (i32.add) (i32.const 0x10))
-  select        ;; Z, S|R5|R3, C, H
-
-  ;; <i32>$arg + <i32>$a + C
-  (i32.shr_s 
-    (i32.shl (get_local $a) (i32.const 24))
-    (i32.const 24)
+  (i32.shr_u 
+    (i32.and (get_local $res) (i32.const 0x100))
+    (i32.const 8)
   )
-  tee_local $pv
-  (i32.shr_s 
-    (i32.shl (get_local $arg) (i32.const 24))
-    (i32.const 24)
+
+  ;; Combine with SZ53 flags
+  (i32.or (call $getSZ53 (get_local $res)))
+
+  ;; Lookup value
+  (call $getR12Lookup (get_local $res) (get_local $a) (get_local $arg))
+  set_local $r12
+
+  ;; Combine with half-carry add
+  (i32.or
+    (i32.load8_u
+      (i32.add
+        (get_global $HC_ADD)
+        (i32.and (get_local $r12) (i32.const 0x07))
+      )
+    )
   )
-  i32.add
-  get_local $c
-  i32.add
-  tee_local $pv
 
-  ;; Calculate PV flag
-  i32.const 0x80
-  i32.ge_s
-  if (result i32)
-    i32.const 0x04
-  else
-    get_local $pv
-    i32.const -0x81
-    i32.le_s
-    if (result i32)
-      i32.const 0x04
-    else
-      i32.const 0x00
-    end
-  end
+  ;; Combine with overflow add
+  (i32.or
+    (i32.load8_u
+      (i32.add
+        (get_global $OVF_ADD)
+        (i32.shr_u (get_local $r12) (i32.const 4))
+      )
+    )
+  )
 
-  ;; Merge flags
-  i32.or
-  i32.or
-  i32.or
-  i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  ;; Done
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; Executes ALU subtraction; sets A and F
@@ -1394,88 +1404,54 @@
 (func $AluSub (param $arg i32) (param $c i32)
   (local $a i32)
   (local $res i32)
-  (local $pv i32)
+  (local $r12 i32)
+
   ;; Subtract values (-carry) and store in A
-  call $getA
-  tee_local $a
-  get_local $arg
-  i32.sub
-  get_local $c
-  i32.sub
+  (tee_local $a (call $getA))
+  (i32.sub (get_local $arg))
+  (i32.sub (get_local $c))
   tee_local $res
   (call $setA (i32.and (i32.const 0xff)))
 
-  ;; Put Z on stack
-  i32.const 0x00 ;; NZ
-  i32.const 0x40 ;; Z
-  (i32.and (get_local $res) (i32.const 0xff))
-  select         ;; Z
-
-  ;; Get S, R5, and R3 from result
-  get_local $res
-  i32.const 0xa8
-  i32.and        ;; Z, S|R5|R3
-
   ;; Get C flag
-  get_local $res
-  i32.const 0x100
-  i32.and
-  i32.const 8
-  i32.shr_u      ;; Z, S|R5|R3, C
-
-  ;; Calculate H flag
-  i32.const 0x10
-  i32.const 0x00
-  (i32.and (get_local $a) (i32.const 0x0f))
-  (i32.and (get_local $arg) (i32.const 0x0f))
-  i32.sub
-  get_local $c
-  i32.sub
-  i32.const 0x10
-  i32.and
-  select        ;; Z, S|R5|R3, C, H
-
-  ;; <i32>$a - <i32>$arg - C
-  (i32.shr_s 
-    (i32.shl (get_local $a) (i32.const 24))
-    (i32.const 24)
+  (i32.shr_u 
+    (i32.and (get_local $res) (i32.const 0x100))
+    (i32.const 8)
   )
-  tee_local $pv
-  (i32.shr_s 
-    (i32.shl (get_local $arg) (i32.const 24))
-    (i32.const 24)
-  )
-  i32.sub
-  get_local $c
-  i32.sub
-  tee_local $pv
-
-  ;; Calculate PV flag
-  i32.const 0x80
-  i32.ge_s
-  if (result i32)
-    i32.const 0x04
-  else
-    get_local $pv
-    i32.const -0x81
-    i32.le_s
-    if (result i32)
-      i32.const 0x04
-    else
-      i32.const 0x00
-    end
-  end
-
-  ;; Merge flags
-  i32.or
-  i32.or
-  i32.or
-  i32.or
 
   ;; Set N
-  i32.const 0x02 ;; N flag mask
-  i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  (i32.or (i32.const 0x02))
+
+  ;; Combine with SZ53 flags
+  (i32.or (call $getSZ53 (get_local $res)))
+
+  ;; Lookup value
+  (call $getR12Lookup (get_local $res) (get_local $a) (get_local $arg))
+  set_local $r12
+
+  ;; Combine with half-carry sub
+  (i32.or
+    (i32.load8_u
+      (i32.add
+        (get_global $HC_SUB)
+        (i32.and (get_local $r12) (i32.const 0x07))
+      )
+    )
+  )
+
+  ;; Combine with overflow sub
+  (i32.or
+    (i32.load8_u
+      (i32.add
+        (get_global $OVF_SUB)
+        (i32.shr_u (get_local $r12) (i32.const 4))
+      )
+    )
+  )
+
+  ;; Done
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; Executes ALU AND operations; sets A and F
@@ -1522,130 +1498,111 @@
 ;; $arg: other argument
 (func $AluCp (param $arg i32)
   (local $res i32)
-  (local $signed i32)
+  (local $r12 i32)
 
   ;; Subtract values
-  call $getA
-  get_local $arg
-  i32.sub
+  (i32.sub (call $getA) (get_local $arg))
   set_local $res
   
-  ;; Signed substract
-  (i32.shl (call $getA) (i32.const 24))
-  (i32.shr_s (i32.const 24))
-  (i32.shl (get_local $arg) (i32.const 24))
-  (i32.shr_s (i32.const 24))
-  i32.sub
-  set_local $signed
+  ;; Get C flag
+  (i32.shr_u 
+    (i32.and (get_local $res) (i32.const 0x100))
+    (i32.const 8)
+  )
 
-  ;; Calculate N flag (set)
-  i32.const 0x02 ;; [N]
+  ;; Combine with Z flag
+  (i32.or
+    (select
+      (i32.const 0x00)
+      (i32.const 0x40)
+      (get_local $res)
+    )
+  )
 
-  ;; Calculate H flag
-  (i32.and (call $getA) (i32.const 0x0f))
-  (i32.and (get_local $arg) (i32.const 0x0f))
-  i32.sub
-  (i32.and (i32.const 0x10)) ;; [N, H] 
+  ;; Set N
+  (i32.or (i32.const 0x02))
 
-  ;; Keep S, R3, and R5 from result
-  (i32.and (get_local $res) (i32.const 0xa8)) ;; [N, H, S|R3|R5]
+  ;; Lookup value
+  (call $getR12Lookup (get_local $res) (call $getA) (get_local $arg))
+  set_local $r12
 
-  ;; Calculate Z flag
-  i32.const 0x00
-  i32.const 0x40
-  (i32.and (get_local $res) (i32.const 0xff))
-  select ;; [N, H, S|R3|R5, Z]
+  ;; Combine with half-carry sub
+  (i32.or
+    (i32.load8_u
+      (i32.add
+        (get_global $HC_SUB)
+        (i32.and (get_local $r12) (i32.const 0x07))
+      )
+    )
+  )
 
-  ;; Calculate C
-  i32.const 0x01
-  i32.const 0x00
-  (i32.and (get_local $res) (i32.const 0x10000))
-  select ;; [N, H, S|R3|R5, Z, C]
+  ;; Combine with overflow sub
+  (i32.or
+    (i32.load8_u
+      (i32.add
+        (get_global $OVF_SUB)
+        (i32.shr_u (get_local $r12) (i32.const 4))
+      )
+    )
+  )
 
-  ;; Calculate PV
-  (i32.ge_s (get_local $signed) (i32.const 0x80))
-  if (result i32)
-    i32.const 0x04
-  else
-    (i32.le_s (get_local $signed) (i32.const -0x81))
-    if (result i32)
-      i32.const 0x04
-    else
-      i32.const 0x00
-    end
-  end
+  ;; Combine with S
+  (i32.or
+    (i32.and (get_local $res) (i32.const 0x80))
+  )
 
-  ;; Merge flags and store them
-  i32.or
-  i32.or
-  i32.or
-  i32.or
-  i32.or
-  (call $setF (i32.and (i32.const 0xff)))
+  ;; Combine with R5 and R3
+  (i32.or
+    (i32.and (get_local $arg) (i32.const 0x28))
+  )
+
+  ;; Done
+  (call $setQ (i32.and (i32.const 0xff)))
+  (call $setF (call $getQ))
 )
 
 ;; Tests the Z condition
 (func $testZ (result i32)
-  (i32.ne 
-    (i32.and (call $getF) (i32.const 0x40))
-    (i32.const 0)
-  )
+  (i32.and (call $getF) (i32.const 0x40))
 )
 
 ;; Tests the NZ condition
 (func $testNZ (result i32)
-  (i32.eq
-    (i32.and (call $getF) (i32.const 0x40))
-    (i32.const 0)
-  )
+  (i32.and (call $getF) (i32.const 0x40))
+  i32.eqz
 )
 
 ;; Tests the C condition
 (func $testC (result i32)
-  (i32.ne
-    (i32.and (call $getF) (i32.const 0x01))
-    (i32.const 0)
-  )
+  (i32.and (call $getF) (i32.const 0x01))
 )
 
 ;; Tests the NC condition
 (func $testNC (result i32)
-  (i32.eq
-    (i32.and (call $getF) (i32.const 0x01))
-    (i32.const 0)
-  )
+  (i32.and (call $getF) (i32.const 0x01))
+  i32.eqz
 )
 
 ;; Tests the PE condition
 (func $testPE (result i32)
-  (i32.ne
-    (i32.and (call $getF) (i32.const 0x04))
-    (i32.const 0)
-  )
+  (i32.and (call $getF) (i32.const 0x04))
 )
 
 ;; Tests the PO condition
 (func $testPO (result i32)
-  (i32.eq
-    (i32.and (call $getF) (i32.const 0x04))
-    (i32.const 0)
-  )
+  (i32.and (call $getF) (i32.const 0x04))
+  i32.eqz
 )
 
 ;; Tests the M condition
 (func $testM (result i32)
-  (i32.ne
-    (i32.and (call $getF) (i32.const 0x80))
-    (i32.const 0)
-  )
+  (i32.and (call $getF) (i32.const 0x80))
 )
 
 ;; Tests the P condition
 (func $testP (result i32)
-  (i32.eq
-    (i32.and (call $getF) (i32.const 0x80))
-    (i32.const 0)
-  )
+  (i32.and (call $getF) (i32.const 0x80))
+  i32.eqz
 )
 
 ;; Read address to WZ

--- a/packages/kliveide-emu/src/native/zx-spectrum-48.wat
+++ b/packages/kliveide-emu/src/native/zx-spectrum-48.wat
@@ -72,7 +72,7 @@
 
   ;; CPU configuration
   i32.const 3_500_000 set_global $baseClockFrequency
-  i32.const 1 set_global $clockMultiplier
+  i32.const 16 set_global $clockMultiplier
   i32.const 0 set_global $supportsNextOperation
   call $resetCpu
   

--- a/packages/kliveide-emu/src/native/zx-spectrum-48.wat
+++ b/packages/kliveide-emu/src/native/zx-spectrum-48.wat
@@ -72,7 +72,7 @@
 
   ;; CPU configuration
   i32.const 3_500_000 set_global $baseClockFrequency
-  i32.const 16 set_global $clockMultiplier
+  i32.const 1 set_global $clockMultiplier
   i32.const 0 set_global $supportsNextOperation
   call $resetCpu
   

--- a/packages/kliveide-emu/src/renderer/spectrum/SpectrumEngine.ts
+++ b/packages/kliveide-emu/src/renderer/spectrum/SpectrumEngine.ts
@@ -629,7 +629,7 @@ export class SpectrumEngine {
       const psgSamples = mh
         .readWords(0, resultState.audioSampleCount)
         .map((smp) =>
-          emuState.muted ? 0 : (smp / 65535) * (emuState.soundLevel ?? 0)
+          emuState.muted ? 0 : (smp / 32768) * (emuState.soundLevel ?? 0)
         );
       this._psgRenderer.storeSamples(psgSamples);
 

--- a/packages/kliveide-emu/test/z80/flags.test.ts
+++ b/packages/kliveide-emu/test/z80/flags.test.ts
@@ -1,0 +1,24 @@
+import "mocha";
+
+describe("Flags generation", () => {
+  it("Generate SZ53_FLAGS/SZ53P_FLAGS", () => {
+    let sz53 = '(data (i32.const 0x40_0A00) "';
+    let sz53p = '(data (i32.const 0x40_0B00) "';
+    for (let i = 0; i < 0x100; i++) {
+      const flags = (i & 0xa8) | (i === 0 ? 0x40 : 0x00);
+      sz53 += `\\${flags.toString(16).padStart(2, "0")}`;
+      let j = i;
+      let parity = 0;
+      for (let k = 0; k < 8; k++) {
+        parity ^= j & 1; 
+        j >>=1;
+      }
+      parity = parity ? 0 : 0x04;
+      sz53p += `\\${(flags | parity).toString(16).padStart(2, "0")}`;
+    }
+    sz53 += '")';
+    console.log(sz53);
+    sz53p += '")';
+    console.log(sz53p);
+  });
+});

--- a/packages/kliveide-emu/test/z80/standard-ops-00-3f.test.ts
+++ b/packages/kliveide-emu/test/z80/standard-ops-00-3f.test.ts
@@ -591,7 +591,7 @@ describe("Standard ops 00-3f", () => {
 
     expect(s.b).toBe(0x00);
     expect(s.pc).toBe(0x0002);
-    expect(s.wz).toBe(0xffff);
+    expect(s.wz).toBe(0x0000);
     expect(s.tacts).toBe(8);
   });
 

--- a/packages/kliveide-emu/test/z80/standard-ops-80-bf.test.ts
+++ b/packages/kliveide-emu/test/z80/standard-ops-80-bf.test.ts
@@ -158,10 +158,10 @@ describe("Standard ops 80-bf", () => {
       testMachine.shouldKeepMemory();
       if (q !== 7) {
         expect(s.a).toBe(0x00);
-        expect(s.f & FlagsSetMask.S).toBeFalsy();
         expect(s.f & FlagsSetMask.Z).toBeTruthy();
-        expect(s.f & FlagsSetMask.PV).toBeFalsy();
         expect(s.f & FlagsSetMask.C).toBeTruthy();
+        expect(s.f & FlagsSetMask.S).toBeFalsy();
+        expect(s.f & FlagsSetMask.PV).toBeFalsy();
       } else {
         expect(s.a).toBe(0xfc);
         expect(s.f & FlagsSetMask.S).toBeTruthy();


### PR DESCRIPTION
The CPU's instructions are zexall compliant except `BIT N,(HL)`