### PR TITLE
fix: allow the ZXB optimization set between 0 and 4.

### DIFF
--- a/packages/kliveide-vsext/package.json
+++ b/packages/kliveide-vsext/package.json
@@ -53,7 +53,7 @@
           "default": 2,
           "description": "The optimization level to use with the --optimize option of ZXBC",
           "minimum": 0,
-          "maximum": 3
+          "maximum": 4
         },
         "kliveIde.zxbcMachineCodeOrigin": {
           "type": "number",


### PR DESCRIPTION
Previously you could set it between 0 and 3.