### PR TITLE
Added z88-specific menu item to online BBC Basic Ref. Guide

### DIFF
--- a/packages/kliveide-emu/src/main/cz-88-context.ts
+++ b/packages/kliveide-emu/src/main/cz-88-context.ts
@@ -52,6 +52,10 @@ const z88Links: LinkDescriptor[] = [
     uri: "https://cambridgez88.jira.com/wiki/spaces/DN/",
   },
   {
+    label: "BBC BASIC (Z80) Reference Guide for Z88",
+    uri: "https://docs.google.com/document/d/1ZFxKYsfNvbuTyErnH5Xtv2aKXWk1vg5TjrAxZnrLsuI",
+  },
+  {
     label: null,
   },
   {


### PR DESCRIPTION
I've added a new menu item for Z88 specific menu, that is the complete 2nd edition of the BBC Basic Reference Guide for Z88, 2nd edition.