### PR TITLE
fixed settings paths:

### DIFF
--- a/packages/kliveide-vsext/src/zxblang/compiler/zxb-runner.ts
+++ b/packages/kliveide-vsext/src/zxblang/compiler/zxb-runner.ts
@@ -79,7 +79,8 @@ export async function execZxbc(
   }
 
   const workdir = path.dirname(execPath);
-  const cmd = `${execPath} ${cmdArgs.split("\\").join("/")}`;
+  const filename = path.basename(execPath);
+  const cmd = `${filename} ${cmdArgs.split("\\").join("/")}`;
   outChannel.appendLine(`Executing ${cmd}`);
   return new Promise<string | null>((resolve, reject) => {
     const process = exec(


### PR DESCRIPTION
-- Zxbc Executable Path: now can use spaces in path

Verified use spaces, / ,or \, for paths:
Emulator Executable Path and Zxbc Executable Path