### PR TITLE
Feature: tape export

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bugs": "https://github.com/Dotneteer/kliveide/issues",
   "homepage": "https://github.com/Dotneteer/kliveide",
   "scripts": {
-    "start": "electron ./dist/main.bundle.js",
+    "start": "electron --inspect ./dist/main.bundle.js",
     "build": "npm run vmbuild && rimraf dist && cross-env NODE_ENV=development webpack --progress --color",
     "dev": "npm run vmbuild && rimraf dist && cross-env NODE_ENV=development webpack --watch --progress --color",
     "prod": "rimraf dist && cross-env NODE_ENV=production webpack --progress --color",

--- a/src/core/main/zx-spectrum-context.ts
+++ b/src/core/main/zx-spectrum-context.ts
@@ -24,9 +24,18 @@ import {
   menuIdFromMachineId,
 } from "../../main/utils/electron-utils";
 
+import { BinaryWriter } from "@core/utils/BinaryWriter";
+import { sendFromMainToEmu } from "@core/messaging/message-sending";
+import { GetSavedTapeContentsResponse } from "@core/messaging/message-types";
+import {
+  TzxHeader,
+  TzxStandardSpeedDataBlock,
+} from "@modules/vm-zx-spectrum/tzx-file";
+
 // --- Menu identifier contants
 const TOGGLE_FAST_LOAD = "sp_toggle_fast_load";
 const SET_TAPE_FILE = "sp_set_tape_file";
+const SAVE_TAPE_FILE = "sp_save_tape_file";
 const DISK_MENU = "sp3e_disk_menu";
 const CREATE_VIRTUAL_DISK = "sp3e_create_virtual_disk";
 const FLOPPY_MENU = "sp3e_floppies";
@@ -96,6 +105,13 @@ export abstract class ZxSpectrumContextProviderBase extends MachineContextProvid
           emuWindow.saveKliveProject();
         },
       },
+      {
+        id: SAVE_TAPE_FILE,
+        label: "Export SAVEd tape data",
+        click: async () => {
+          await this.exportSavedTapeData();
+        },
+      },
     ];
   }
 
@@ -108,6 +124,13 @@ export abstract class ZxSpectrumContextProviderBase extends MachineContextProvid
     if (toggleFastLoad) {
       toggleFastLoad.checked = !!state.spectrumSpecific?.fastLoad;
       emuWindow.saveKliveProject();
+    }
+    const exportSavedTapeMenu = menu.getMenuItemById(SAVE_TAPE_FILE);
+    if (exportSavedTapeMenu) {
+      exportSavedTapeMenu.visible =
+        state.emulatorPanel?.extraFeatures?.includes("Tape") &&
+        (state.emulatorPanel?.executionState === 1 ||
+          state.emulatorPanel?.executionState === 3);
     }
   }
 
@@ -201,7 +224,7 @@ export abstract class ZxSpectrumContextProviderBase extends MachineContextProvid
             type: "info",
           });
         } else {
-          throw new Error("Could not process the contenst of tape file.");
+          throw new Error("Could not process the contents of tape file.");
         }
       } catch (err) {
         // --- This error is intentionally ignored
@@ -215,6 +238,41 @@ export abstract class ZxSpectrumContextProviderBase extends MachineContextProvid
         });
       }
     }
+  }
+
+  private async exportSavedTapeData() : Promise<void> {
+    const window = emuWindow.window;
+    const result = await dialog.showSaveDialog(window, {
+      title: "Save tape file",
+      defaultPath: "new_tape.tzx",
+      filters: [
+        { name: "Tape file", extensions: ["tzx"] },
+      ],
+    });
+
+    if (result.canceled) return;
+
+    const response = (await sendFromMainToEmu({
+      type: "GetSavedTapeContents"
+    })) as GetSavedTapeContentsResponse;
+    const data = response.data ?? new Uint8Array();
+
+    // --- We use this writer to save file info into
+    const writer = new BinaryWriter();
+    new TzxHeader().writeTo(writer);
+    // --- The first 19 bytes is the header
+    new TzxStandardSpeedDataBlock(data.slice(0, 19)).writeTo(writer);
+    // --- Other bytes are the data block
+    new TzxStandardSpeedDataBlock(data.slice(19)).writeTo(writer);
+
+    const tapeFile = result.filePath;
+    fs.writeFileSync(tapeFile, writer.buffer);
+
+    await dialog.showMessageBox(window, {
+      title: `Saved Tape data exported`,
+      message: `Tape file ${tapeFile} successfully saved.`,
+      type: "info",
+    });
   }
 }
 

--- a/src/core/messaging/message-types.ts
+++ b/src/core/messaging/message-types.ts
@@ -154,6 +154,13 @@ export interface ExecuteMachineCommandRequest extends MessageBase {
 }
 
 /**
+ * The main process sends this message to Emu to get saved tape data
+ */
+export interface GetSavedTapeContentsRequest extends MessageBase {
+  type: "GetSavedTapeContents";
+}
+
+/**
  * The main process sends its entire state to the IDE window
  */
 export interface SyncMainStateRequest extends MessageBase {
@@ -399,7 +406,8 @@ type MainToEmuRequests =
   | StepOverVmRequest
   | StepOutVmRequest
   | RunCodeRequest
-  | ExecuteMachineCommandRequest;
+  | ExecuteMachineCommandRequest
+  | GetSavedTapeContentsRequest;
 
 /**
  * Requests from Emu to Main
@@ -464,6 +472,14 @@ export interface CreateMachineResponse extends MessageBase {
 export interface ExecuteMachineCommandResponse extends MessageBase {
   type: "ExecuteMachineCommandResponse";
   result: unknown;
+}
+
+/**
+ * Response for GetSavedTapeContentsRequest
+ */
+export interface GetSavedTapeContentsResponse extends MessageBase {
+  type: "GetSavedTapeContentsResponse";
+  data?: Uint8Array;
 }
 
 /**
@@ -601,6 +617,7 @@ export type ResponseMessage =
   | DefaultResponse
   | CreateMachineResponse
   | ExecuteMachineCommandResponse
+  | GetSavedTapeContentsResponse
   | EmuOpenFileDialogResponse
   | GetCpuStateResponse
   | GetMachineStateResponse

--- a/src/emu/emu-message-processor.ts
+++ b/src/emu/emu-message-processor.ts
@@ -5,10 +5,12 @@ import {
   CreateMachineResponse,
   DefaultResponse,
   ExecuteMachineCommandResponse,
+  GetSavedTapeContentsResponse,
   RequestMessage,
   ResponseMessage,
 } from "@core/messaging/message-types";
 import { getVmEngineService } from "@modules-core/vm-engine-service";
+import { ZxSpectrumCoreBase } from "@modules/vm-zx-spectrum/ZxSpectrumCoreBase"
 
 // --- Electron APIs exposed for the renderer process
 const ipcRenderer = (window as any).ipcRenderer as IpcRendereApi;
@@ -91,6 +93,21 @@ async function processEmulatorMessages(
         };
       }
       return <DefaultResponse>{ type: "Ack" };
+
+    case "GetSavedTapeContents": {
+      if (vmEngineService.hasEngine) {
+        var sp = vmEngineService.getEngine() as ZxSpectrumCoreBase;
+        if (sp) {
+          return <GetSavedTapeContentsResponse>{
+            type: "GetSavedTapeContentsResponse",
+            data: sp.getSavedTapeContents(),
+          };
+        }
+      }
+      return <GetSavedTapeContentsResponse>{
+        type: "GetSavedTapeContentsResponse"
+      };
+    }
 
     default:
       return <DefaultResponse>{ type: "Ack" };

--- a/src/emu/emu-renderer.tsx
+++ b/src/emu/emu-renderer.tsx
@@ -59,7 +59,17 @@ class SampleRateGetter
 {
   readonly id = AUDIO_SAMPLE_RATE_GETTER_ID;
   getAudioSampleRate() {
-    return new AudioContext().sampleRate;
+    try { 
+      var ctx = new AudioContext();
+      return ctx.sampleRate;
+    }
+    finally {
+      // The specification doesn't go into a lot of detail about things like how many
+      // audio contexts a user agent should support, or minimum or maximum latency
+      // requirements (if any), so these details can vary from browser to browser.
+      // More details: https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/AudioContext
+      ctx?.close().catch(console.error);
+    }
   }
 }
 

--- a/src/main/app/app-menu.ts
+++ b/src/main/app/app-menu.ts
@@ -789,45 +789,6 @@ export function processStateChange(fullState: AppState): void {
 
   // --- Take care that custom machine menus are updated
   emuWindow.machineContextProvider?.updateMenuStatus(fullState);
-
-  // // --- The engine has just saved a ZX Spectrum file
-  // if (emuState?.savedData && emuState.savedData.length > 0) {
-  //   const data = emuState.savedData;
-  //   const ideConfig = mainProcessStore.getState().ideConfiguration;
-  //   if (!ideConfig) {
-  //     return;
-  //   }
-
-  //   // --- Create filename
-  //   const tapeFilePath = path.join(
-  //     ideConfig.projectFolder,
-  //     ideConfig.saveFolder
-  //   );
-  //   const nameBytes = data.slice(2, 12);
-  //   let name = "";
-  //   for (let i = 0; i < 10; i++) {
-  //     name += String.fromCharCode(nameBytes[i]);
-  //   }
-  //   const tapeFileName = path.join(tapeFilePath, `${name.trimRight()}.tzx`);
-
-  //   // --- We use this writer to save file info into
-  //   const writer = new BinaryWriter();
-  //   new TzxHeader().writeTo(writer);
-
-  //   // --- The first 19 bytes is the header
-  //   new TzxStandardSpeedDataBlock(data.slice(0, 19)).writeTo(writer);
-
-  //   // --- Other bytes are the data block
-  //   new TzxStandardSpeedDataBlock(data.slice(19)).writeTo(writer);
-
-  //   // --- Now, save the file
-  //   fs.writeFileSync(tapeFileName, writer.buffer);
-
-  //   // --- Sign that the file has been saved
-  //   mainProcessStore.dispatch(
-  //     emulatorSetSavedDataAction(new Uint8Array(0))()
-  //   );
-  // }
 }
 
 // ============================================================================

--- a/src/modules/core/memory-helpers.ts
+++ b/src/modules/core/memory-helpers.ts
@@ -12,7 +12,7 @@ export class MemoryHelper {
    * @param ptr Memory pointer this helper works with
    */
   constructor(public wasmApi: WasmCpuApi, public ptr: number) {
-    this._memory = new Uint8Array(wasmApi.memory.buffer, 0);
+    this._memory = new Uint8Array(wasmApi.memory.buffer, ptr);
   }
 
   /**
@@ -20,7 +20,6 @@ export class MemoryHelper {
    * @param offs Offset value
    */
   readByte(offs: number): number {
-    offs += this.ptr;
     return this._memory[offs];
   }
 
@@ -30,7 +29,6 @@ export class MemoryHelper {
    * @param length #of bytes to read
    */
   readBytes(offs: number, length: number): number[] {
-    offs += this.ptr;
     const result: number[] = [];
     for (let i = 0; i < length; i++) {
       result[i] = this._memory[offs + i];
@@ -44,7 +42,6 @@ export class MemoryHelper {
    * @param length #of bytes to read
    */
   readWords(offs: number, length: number): number[] {
-    offs += this.ptr;
     const result: number[] = [];
     for (let i = 0; i < length; i++) {
       result[i] =
@@ -58,7 +55,6 @@ export class MemoryHelper {
    * @param offs Offset value
    */
   writeByte(offs: number, value: number): void {
-    offs += this.ptr;
     this._memory[offs] = value & 0xff;
   }
 
@@ -67,7 +63,6 @@ export class MemoryHelper {
    * @param offs Offset value
    */
   readBool(offs: number): boolean {
-    offs += this.ptr;
     return this._memory[offs] !== 0;
   }
 
@@ -76,7 +71,6 @@ export class MemoryHelper {
    * @param offs Offset value
    */
   writeBool(offs: number, value: boolean): void {
-    offs += this.ptr;
     this._memory[offs] = value ? 1 : 0;
   }
 
@@ -85,7 +79,6 @@ export class MemoryHelper {
    * @param offs Offset value
    */
   readUint16(offs: number): number {
-    offs += this.ptr;
     return this._memory[offs] + (this._memory[offs + 1] << 8);
   }
 
@@ -94,7 +87,6 @@ export class MemoryHelper {
    * @param offs Offset value
    */
   writeUint16(offs: number, value: number): void {
-    offs += this.ptr;
     this._memory[offs] = value & 0xff;
     this._memory[offs + 1] = (value >> 8) & 0xff;
   }
@@ -104,7 +96,6 @@ export class MemoryHelper {
    * @param offs Offset value
    */
   readUint32(offs: number): number {
-    offs += this.ptr;
     return (
       this._memory[offs] +
       (this._memory[offs + 1] << 8) +
@@ -118,7 +109,6 @@ export class MemoryHelper {
    * @param offs Offset value
    */
   writeUint32(offs: number, value: number): void {
-    offs += this.ptr;
     this._memory[offs] = value & 0xff;
     this._memory[offs + 1] = (value >> 8) & 0xff;
     this._memory[offs + 2] = (value >> 16) & 0xff;

--- a/src/modules/core/vm-engine-service.ts
+++ b/src/modules/core/vm-engine-service.ts
@@ -283,7 +283,7 @@ class VmEngineService implements IVmEngineService {
     if (this._vmEngine) {
       return this._vmEngine;
     }
-    throw new Error("The is now virtual machine engine set");
+    throw new Error("There is no virtual machine engine set");
   }
 
   /**

--- a/src/modules/vm-zx-spectrum/ZxSpectrumCoreBase.ts
+++ b/src/modules/vm-zx-spectrum/ZxSpectrumCoreBase.ts
@@ -6,6 +6,7 @@ import {
   COLORIZATION_BUFFER,
   PSG_SAMPLE_BUFFER,
   RENDERING_TACT_TABLE,
+  TAPE_SAVE_BUFFER,
 } from "@modules/vm-zx-spectrum/wa-memory-map";
 import {
   MachineCreationOptions,
@@ -314,11 +315,12 @@ export abstract class ZxSpectrumCoreBase extends Z80MachineCoreBase {
     s.tapeStartTactH = mh.readUint32(161);
     s.tapeFastLoad = mh.readBool(165);
     s.tapeSavePhase = mh.readByte(166);
+    s.tapeSaveDataLen = mh.readUint32(167);
 
     // --- Engine state
-    s.ulaIssue = mh.readByte(167);
-    s.contentionAccumulated = mh.readUint32(168);
-    s.lastExecutionContentionValue = mh.readUint32(172);
+    s.ulaIssue = mh.readByte(171);
+    s.contentionAccumulated = mh.readUint32(172);
+    s.lastExecutionContentionValue = mh.readUint32(176);
 
     // --- Screen rendering tact
     mh = new MemoryHelper(this.api, RENDERING_TACT_TABLE);
@@ -329,6 +331,17 @@ export abstract class ZxSpectrumCoreBase extends Z80MachineCoreBase {
 
     // --- Done.
     return s;
+  }
+
+  /**
+   * Gets saved tape contents buffer
+   */
+  getSavedTapeContents(): Uint8Array {
+    // --- Obtain ZX Spectrum specific state
+    this.api.getMachineState();
+    let mh = new MemoryHelper(this.api, VM_STATE_BUFFER);
+    return new Uint8Array(this.api.memory.buffer,
+      TAPE_SAVE_BUFFER, mh.readUint32(167));
   }
 
   /**
@@ -781,6 +794,7 @@ export interface SpectrumMachineStateBase extends MachineState, Z80CpuState {
   tapeStartTactH: number;
   tapeFastLoad: boolean;
   tapeSavePhase: number;
+  tapeSaveDataLen: number;
 
   // --- Engine state
   ulaIssue: number;

--- a/src/modules/vm-zx-spectrum/ZxSpectrumCoreBase.ts
+++ b/src/modules/vm-zx-spectrum/ZxSpectrumCoreBase.ts
@@ -177,15 +177,6 @@ export abstract class ZxSpectrumCoreBase extends Z80MachineCoreBase {
   }
 
   /**
-   * Optional import properties for the WebAssembly engine
-   */
-  readonly waImportProps: Record<string, any> = {
-    saveModeLeft: (length: number) => {
-      this.storeSavedDataInState(length);
-    },
-  };
-
-  /**
    * Creates the CPU instance
    */
   configureMachine(): void {
@@ -494,19 +485,6 @@ export abstract class ZxSpectrumCoreBase extends Z80MachineCoreBase {
     }
     const mh = new MemoryHelper(this.api, BREAKPOINTS_MAP);
     mh.writeByte(def.location, 0x01);
-  }
-
-  /**
-   * Extracts saved data
-   * @param length Data length
-   */
-  storeSavedDataInState(length: number): void {
-    // if (!vmEngine) {
-    //   return;
-    // }
-    // const mh = new MemoryHelper(vmEngine.z80Machine.api, TAPE_SAVE_BUFFER);
-    // const savedData = new Uint8Array(mh.readBytes(0, length));
-    // rendererProcessStore.dispatch(emulatorSetSavedDataAction(savedData)());
   }
 
   // ==========================================================================

--- a/src/modules/vm-zx-spectrum/wa-memory-map.ts
+++ b/src/modules/vm-zx-spectrum/wa-memory-map.ts
@@ -23,7 +23,7 @@ export const COLORIZATION_BUFFER = 0x012e_a9e8;
 export const BEEPER_SAMPLE_BUFFER = 0x013d_ae38;
 
 // --- AY PSG chip samples
-export const PSG_SAMPLE_BUFFER = 0x0100_210b;
+export const PSG_SAMPLE_BUFFER = 0x0100_210f;
 
 // --- Tape LOAD buffer
 export const TAPE_DATA_BUFFER = 0x0138_ae30;

--- a/src/test/z80/import-object.ts
+++ b/src/test/z80/import-object.ts
@@ -4,7 +4,6 @@
 export const importObject = {
   imports: {
     trace: (arg: number) => console.log(arg),
-    saveModeLeft: () => {},
     opCodeFetched: () => {},
     standardOpExecuted: () => {},
     extendedOpExecuted: () => {},

--- a/src/wats/sp128-core/sp128.wats
+++ b/src/wats/sp128-core/sp128.wats
@@ -2,7 +2,6 @@
 // ZX Spectrum 128K machine implementation
 // ============================================================================
 import void trace "imports" "trace" (u32);
-import void saveModeLeft "imports" "saveModeLeft" (u32);
 
 // --- Sign that ZX Spectrum models have contended memory
 #define MEM_CONTENDED

--- a/src/wats/sp48-core/sp48.wats
+++ b/src/wats/sp48-core/sp48.wats
@@ -2,7 +2,6 @@
 // ZX Spectrum 48K machine implementation
 // ============================================================================
 import void trace "imports" "trace" (u32);
-import void saveModeLeft "imports" "saveModeLeft" (u32);
 
 // --- Sign that ZX Spectrum models have contended memory
 #define MEM_CONTENDED

--- a/src/wats/spectrum-core/machine.wats
+++ b/src/wats/spectrum-core/machine.wats
@@ -262,7 +262,8 @@ export void resetMachine() {
   tapeEof = false;
   tapeBufferPtr = &tapeDataBuffer;
   tapeFastLoad = false;
-  
+  tapeSaveDataLen = 0;
+
   // --- Reset debugging state
   stepOutStackDepth = 0;
 }

--- a/src/wats/spectrum-core/machine.wats
+++ b/src/wats/spectrum-core/machine.wats
@@ -89,6 +89,7 @@ type spMachineState = struct {
   u64 tapeStartTact,
   bool tapeFastLoad,
   u8 tapeSavePhase,
+  u32 tapeSaveDataLen,
 
   // --- Engine state
   u8 ulaIssue,
@@ -200,6 +201,7 @@ export void getMachineState() {
   spectrumMachineStateBuffer.tapeStartTact = tapeStartTact;
   spectrumMachineStateBuffer.tapeFastLoad = tapeFastLoad;
   spectrumMachineStateBuffer.tapeSavePhase = tapeSavePhase;
+  spectrumMachineStateBuffer.tapeSaveDataLen = tapeSaveDataLen;
 
   // --- Engine state
   spectrumMachineStateBuffer.ulaIssue = ulaIssue;

--- a/src/wats/spectrum-core/sound-device.wats
+++ b/src/wats/spectrum-core/sound-device.wats
@@ -130,7 +130,7 @@ void initSound(*psgState psgPtr) {
   psgNextClockTact = PSG_CLOCK_STEP;
 }
 
-// Initializes the PSG envelop tables
+// Initializes the PSG envelope tables
 void initEnvelopeTables() {
   // Reset the sample pointer
   local *u8 samplePtr = &psgEnvelopes;
@@ -178,7 +178,7 @@ void initEnvelopeTables() {
         }
       }
 
-      // --- Store the envelop sample and move to the next position
+      // --- Store the envelope sample and move to the next position
       (*samplePtr) = vol;
       samplePtr += 1;
       pos += 1;
@@ -189,7 +189,7 @@ void initEnvelopeTables() {
   }
 }
 
-// Reads the value of the selected PSG reginster
+// Reads the value of the selected PSG register
 u8 readPsgRegisterValue(*psgState psgPtr) {
   return (*psgPtr).regs[psgRegisterIndex & 0x0f];
 }

--- a/src/wats/spectrum-core/tape-device.wats
+++ b/src/wats/spectrum-core/tape-device.wats
@@ -8,7 +8,7 @@
 // Pilot pulse length
 const u64 PILOT_PULSE = 2168;
 
-// Pilot pulses in the header blcok
+// Pilot pulses in the header bloсk
 const u64 HEADER_PILOT_COUNT = 8063;
 
 // Pilot pulses in the data block
@@ -207,7 +207,7 @@ void checkTapeHooks() {
       // --- Turn on SAVE mode
       tapeMode = TM_SAVE;
       tapeLastMicBitTact = getCurrentTactAsI64();
-      tapeLastMicBit = 0x08;
+      tapeLastMicBit = 0x07;
       tapeSavePhase = SP_NONE;
       tapePilotPulseCount = 0;
       tapeDataBlockCount = 0;
@@ -223,19 +223,11 @@ void checkTapeHooks() {
       tapeMode = TM_PASSIVE;
       return;
     }
-
-    // --- Tape Error?
-    if (pc == 0x0008) {
-      tapeMode = TM_PASSIVE;
-    }
-    return;
   }
 
-  // --- SAVE Mode. Error or too long pause?
-  if (pc == 0x0008 | (getCurrentTactAsI64() - tapeLastMicBitTact) > TOO_LONG_PAUSE) {
-    // --- Leave the SAVE mode
+  // --- Tape Error?
+  if (pc == 0x0008) {
     tapeMode = TM_PASSIVE;
-    saveModeLeft(tapeSaveDataLen);
   }
 }
 

--- a/src/wats/spectrum-core/tape-device.wats
+++ b/src/wats/spectrum-core/tape-device.wats
@@ -226,7 +226,7 @@ void checkTapeHooks() {
   }
 
   // --- Tape Error?
-  if (pc == 0x0008) {
+  if (pc == 0x0008 | (getCurrentTactAsI64() - tapeLastMicBitTact) > TOO_LONG_PAUSE) {
     tapeMode = TM_PASSIVE;
   }
 }
@@ -482,7 +482,8 @@ void processMicBit(u32 micBit) {
   }
 
   // --- MIC bit changed, process it
-  local u64 length = getCurrentTactAsI64() - tapeLastMicBitTact;
+  local u64 bitTact = getCurrentTactAsI64();
+  local u64 length = bitTact - tapeLastMicBitTact;
 
   // --- Initialize pulse
   local u32 pulse = PL_NONE;
@@ -508,6 +509,7 @@ void processMicBit(u32 micBit) {
 
   // --- Now, we have a categorized pulse
   tapeLastMicBit = micBit;
+  tapeLastMicBitTact = bitTact;
 
   // --- Let's process the pulse according to the current SAVE phase and pulse width
   nextPhase = SP_ERROR;
@@ -550,9 +552,9 @@ void processMicBit(u32 micBit) {
     }
   } else if ((pulse == PL_BIT_0) | (pulse == PL_BIT_1)) {
     if (!tapePrevDataPulse) {
-    // --- We are waiting for the second half of the bit pulse
-    tapePrevDataPulse = pulse;
-    nextPhase = SP_DATA;
+      // --- We are waiting for the second half of the bit pulse
+      tapePrevDataPulse = pulse;
+      nextPhase = SP_DATA;
     } else if (tapePrevDataPulse == pulse) {
       // --- We received a full valid bit pulse
       tapePrevDataPulse = 0;

--- a/src/wats/spectrum-core/tape-device.wats
+++ b/src/wats/spectrum-core/tape-device.wats
@@ -207,7 +207,7 @@ void checkTapeHooks() {
       // --- Turn on SAVE mode
       tapeMode = TM_SAVE;
       tapeLastMicBitTact = getCurrentTactAsI64();
-      tapeLastMicBit = 0x07;
+      tapeLastMicBit = 0xFF;
       tapeSavePhase = SP_NONE;
       tapePilotPulseCount = 0;
       tapeDataBlockCount = 0;
@@ -508,8 +508,8 @@ void processMicBit(u32 micBit) {
   }
 
   // --- Now, we have a categorized pulse
-  tapeLastMicBit = micBit;
   tapeLastMicBitTact = bitTact;
+  tapeLastMicBit = micBit;
 
   // --- Let's process the pulse according to the current SAVE phase and pulse width
   nextPhase = SP_ERROR;

--- a/src/wats/spectrum-core/tape-device.wats
+++ b/src/wats/spectrum-core/tape-device.wats
@@ -166,8 +166,10 @@ global u32 tapeDataByte;
 // Buffer for LOAD data
 u8[0x4'0000] tapeDataBuffer;
 
+const u32 TAPE_SAVE_BUFFER_LENGTH = 0x1'0000;
+
 // Buffer for SAVE data
-u8[0x1'0000] tapeSaveBuffer;
+u8[TAPE_SAVE_BUFFER_LENGTH] tapeSaveBuffer;
 
 // ==========================================================================
 // Tape device routines
@@ -184,6 +186,8 @@ export void initTape (u32 blocks) {
   // --- Rewind to the first data block to play
   tapeBufferPtr = &tapeDataBuffer;
   tapeEof = false;
+
+  tapeSaveDataLen = 0;
 }
 
 // Checks if tape device hook should be applied
@@ -212,7 +216,6 @@ void checkTapeHooks() {
       tapePilotPulseCount = 0;
       tapeDataBlockCount = 0;
       tapePrevDataPulse = 0;
-      tapeSaveDataLen = 0;
     }
     return;
   }
@@ -223,6 +226,16 @@ void checkTapeHooks() {
       tapeMode = TM_PASSIVE;
       return;
     }
+    if (pc == 0x0008) {
+      tapeMode = TM_PASSIVE;
+    }
+    return;
+  }
+
+  // --- processMicBit Error?
+  if (tapeSavePhase == SP_ERROR) {
+    tapeMode = TM_PASSIVE;
+    return;
   }
 
   // --- Tape Error?
@@ -571,10 +584,16 @@ void processMicBit(u32 micBit) {
         // --- Save the received data
         tapeSaveBuffer[tapeSaveDataLen] = tapeDataByte;
         tapeSaveDataLen += 1;
-      
+
         // --- Reset byte state
         tapeDataByte = 0;
         tapeBitOffs = 0;
+
+        if (tapeSaveDataLen >= TAPE_SAVE_BUFFER_LENGTH) {
+          tapeSaveDataLen = 0;
+          nextPhase = SP_ERROR;
+          return;
+        }
       }
     }
   } else if (pulse == PL_TERM) {

--- a/src/wats/spp3e-core/spp3e.wats
+++ b/src/wats/spp3e-core/spp3e.wats
@@ -2,7 +2,6 @@
 // ZX Spectrum 3+E machine implementation
 // ============================================================================
 import void trace "imports" "trace" (u32);
-import void saveModeLeft "imports" "saveModeLeft" (u32);
 
 // --- Sign that ZX Spectrum models have contended memory
 #define MEM_CONTENDED


### PR DESCRIPTION
Greetings, @Dotneteer. 👋  I liked your IDE pretty much, but couldn't figure out how to materialize the compiled machine code. After a few days of research I came with this approach that enables IDE users to export the compiled ZX Spectrum programs as tape files.

The feature is meant to be as follows:
First, user prepares the code/data RAM layout by either compiling the project sources or by entering them manually while interacting with virtual machine. Next, user saves the desired parts on tape. After, the saved tape buffer is exported into TZX file via 'Machine->Export SAVEd tape data' menu option.

Here it is a [new_tape.zip](https://github.com/Dotneteer/kliveide/files/12167103/new_tape.zip) file obtained the way described above. The tape is comprised of:
1. 'p' - a little program, load it as CODE
2. 'scr' - SCREEN$ picture
3. 'text' - a string of text DATA
 
In my opinion it is a reasonable trade-off as opposed to the number of the user actions required.