### PR TITLE
Minor typos fixed across GitHub pages body of content.

### DIFF
--- a/docs/_posts/documents/2021-01-01-directives.md
+++ b/docs/_posts/documents/2021-01-01-directives.md
@@ -43,7 +43,7 @@ works in concert with __#ELSE__ and __#ENDIF__:
 ```
 
 Here, __Block #1__ does not generate output, since the condition is false. __Block #2__ emits
-a `nop`, as the condition is true. The fals condition value in __Block #3__ moves code
+a `nop`, as the condition is true. The false condition value in __Block #3__ moves code
 parsing to the `#else` branch, so it emits a `ld b,c` instruction.
 
 ## The #IFDEF and #IFNDEF Directives
@@ -110,7 +110,7 @@ According to this definition, the first block emits a `ld, a,b` instruction, the
 You can use this directive to load and process a source file from within another source file.
 
 __#INCLUDE__ accepts a string that names a file with its extension. The file name may contain either
-an absolute or a relative path. When a relative path is provided, its strating point is always
+an absolute or a relative path. When a relative path is provided, its starting point is always
 the source file that holds the __#INCLUDE__ directive.
 
 Assume that this code is in the `C:\Work` folder:
@@ -121,5 +121,5 @@ Assume that this code is in the `C:\Work` folder:
 #include "/Common/scroll.z80asm"
 ```
 
-The compiler will check the ```C:\Work``` folder for the first two include filem and
+The compiler will check the ```C:\Work``` folder for the first two include files and
 ```C:\Work\Commmon``` for the third one.

--- a/docs/_posts/documents/2021-01-01-expressions.md
+++ b/docs/_posts/documents/2021-01-01-expressions.md
@@ -78,7 +78,7 @@ takes a note (it is called a *fixup*) when `MyVal` gets a value, the two #00 byt
 should be updated accordingly.
 
 ## Operands
-You can use the following operands in epressions:
+You can use the following operands in expressions:
 * Boolean, Decimal and hexadecimal literals
 * Character literals
 * Identifiers
@@ -89,7 +89,7 @@ You can use the following operands in epressions:
 ## Operators
 
 You can use about a dozen operators, including unary, binary and ternary ones. In this section
-you will learn about them. I will introduce them in descending order of their precendence.
+you will learn about them. I will introduce them in descending order of their precedence.
 
 ### Conditional Operator
 
@@ -163,7 +163,7 @@ Operator token | Precedence | Description
 `~` | 10 | Unary bitwise NOT
 `!` | 10 | Unary logical NOT
 
-> Do not forget, you can change the defult precendence with `(` and `)`, or with `[` and `]`.
+> Do not forget, you can change the default precedence with `(` and `)`, or with `[` and `]`.
 
 ## Functions
 
@@ -191,7 +191,7 @@ Signature | Value | Description
 `atan(float)` | `float` | The angle whose tangent is the specified number.
 `atan2(float, float)` | `float` | The angle whose tangent is the quotient of two specified numbers.
 `attr(integer, integer, boolean, boolean)` | `integer` | Retrieves the color attribute byte value defined by `ink` (first argument, 0 to 7), `paper` (second argument, 0 to 7), `bright` (third argument, 0 - non-zero), and `flash` (fourth argument, 0 - non-zero). The `bright` and `flash` values are optional.
-`attraddr(integer, integer)` | `integer` | Returns the memory address of the byte specified screen attribute in the given line (first argument, from top to bottom, 0-192) and column (second argumment, from left to right, 0-255).`ceiling(float)`
+`attraddr(integer, integer)` | `integer` | Returns the memory address of the byte specified screen attribute in the given line (first argument, from top to bottom, 0-192) and column (second argument, from left to right, 0-255).`ceiling(float)`
 `bright(boolean)` | `integer` | Retrieves the bright flag defined by the attribute (0 - non-zero). Can be ORed to create color attribute value.
 `ceiling(float`) | `float` | The smallest integral value that is greater than or equal to the specified number.
 `cos(float)` | `float` | The cosine of the specified angle.

--- a/docs/_posts/documents/2021-01-01-how-assembler-works.md
+++ b/docs/_posts/documents/2021-01-01-how-assembler-works.md
@@ -27,7 +27,7 @@ which is defined somewhere later in the code. When the assembler detects such a 
 a note of it &mdash; it creates a *fixup* entry.
 
 1. The assembler goes through all fixup entries and resolves symbols that were not defined in
-the previous phase. Of course, it might find unknows symbols. If this happens, the assembler reports
+the previous phase. Of course, it might find unknown symbols. If this happens, the assembler reports
 an error.
 
 > Several pragmas and statements intend to evaluate an expression in phase 3. If they find an

--- a/docs/_posts/documents/2021-01-01-labels-and-symbols.md
+++ b/docs/_posts/documents/2021-01-01-labels-and-symbols.md
@@ -39,7 +39,7 @@ This code is entirely correct. Note, the `ld b,32` instruction belongs to the `M
 
 As you will learn later, you can define symbols with the `.EQU` or `.VAR` pragmas. While `.EQU` allows you to assign a constant value to a symbol &mdash; and so it cannot change its value after the declaration, `.VAR` let's you re-assign the initial value.
 
-__Klive__ supports the idea of lexical scopes. When you create the program, it starts with a global (outermost) lexical scope. Particular language elements, such a _statements_ create their own nested lexical scope. Labels and symbols are always created within the current lexical scope. Nonetheless, when resolving them, the assembler starts with the innermost scope and goes through all outers scopes until it manages to find the label declaration.
+__Klive__ supports the idea of lexical scopes. When you create the program, it starts with a global (outermost) lexical scope. Particular language elements, such a _statements_ create their own nested lexical scope. Labels and symbols are always created within the current lexical scope. Nonetheless, when resolving them, the assembler starts with the innermost scope and goes through all outer scopes until it manages to find the label declaration.
 This mechanism means that you can declare labels within a nested scope so that those hide labels and symbols in outer scopes.
 You can learn more about this topic in the __Statements__ section.
 

--- a/docs/_posts/documents/2021-01-01-language-structure.md
+++ b/docs/_posts/documents/2021-01-01-language-structure.md
@@ -42,7 +42,7 @@ djNZ MyLabel
 ```
 
 In symbolic names (labels, identifiers, etc.), you can mix lowercase and uppercase letters. Nonetheless, the compiler applies
-case-insensitive comparison when mathcing symbolic names. So, these statement pairs are totally equivalent with
+case-insensitive comparison when matching symbolic names. So, these statement pairs are totally equivalent with
 each other:
 ```
 jp MainEx
@@ -70,7 +70,7 @@ Wait:   ld b,8     ; Set the counter
 Wait1:  djnz Wait1 // wait while the counter reaches zero
 ```
 
-Block comments can be put anywhere within an instruction line betwen `/*` and `*/` tokens, until they do not break other tokens. Nonetheless, block comments cannot span multiple lines, they must start and end within the same source code line. All of the block comments in this code snippet are correct:
+Block comments can be put anywhere within an instruction line between `/*` and `*/` tokens, until they do not break other tokens. Nonetheless, block comments cannot span multiple lines, they must start and end within the same source code line. All of the block comments in this code snippet are correct:
 
 ```
 SetAttr:
@@ -202,7 +202,7 @@ respectively), such as in these samples:
 
 ZX Spectrum has a character set with special control characters such as AT, INK, PAPER, and so on.
 
-The __SpectNetIde__ assembler allows you to define them with special escape sequences:
+The __SpectNetIDE__ assembler allows you to define them with special escape sequences:
 
 Escape | Code | Character
 -------|------|----------

--- a/docs/_posts/documents/2021-01-01-macros.md
+++ b/docs/_posts/documents/2021-01-01-macros.md
@@ -90,7 +90,7 @@ ld b,d
 DelayLoop_2: djnz DelayLoop_2
 ```
 
-Macros allow you to pass anything that could be an operand in a Z80 instruction, so this is entirelly valid:
+Macros allow you to pass anything that could be an operand in a Z80 instruction, so this is entirely valid:
 
 ```
 Delay((ix+23))
@@ -103,7 +103,7 @@ ld b,(ix+23)
 DelayLoop: djnz DelayLoop
 ```
 
-__Klive__ macros do not stop here. You can define macros that recveive an entire Z80 instruction
+__Klive__ macros do not stop here. You can define macros that receive an entire Z80 instruction
 as an argument:
 
 {% raw %}
@@ -369,7 +369,7 @@ MyMacro(a, b, c, d) ; ERROR: To many parameters
 ```
 
 Sometimes it is convenient to omit not the last parameters but one in the beginning or the middle of the
-parameter list. You can do that: an empy comma separator signs that the preceeding parameter is empty. Using this
+parameter list. You can do that: an empty comma separator signs that the preceding parameter is empty. Using this
 notation, all these invocations of `MyMacro` is valid:
 
 ```
@@ -397,7 +397,7 @@ LdBcDeHl:
 ```
 {% endraw %}
 
-The `def()` function accepts only a macro argument reference (the name of the argument wrapped in double curlay braces).
+The `def()` function accepts only a macro argument reference (the name of the argument wrapped in double curly braces).
 This function evaluates to true only when the macro argument is not empty. 
 
 You can use the logical NOT operator (`!`) combined to `def()` to check if an argument is empty.

--- a/docs/_posts/documents/2021-01-01-main-features.md
+++ b/docs/_posts/documents/2021-01-01-main-features.md
@@ -13,7 +13,7 @@ The original goal of the __Klive__ assembler was to have a simple tool that allo
 Z80 assembly code and inject it into the ZX Spectrum virtual machine. As the community has started
 using it, I've been receiving feature requests to add some useful capability to the Assembler.
 
-Here is a list of important features the __Klive__ suports:
+Here is a list of important features the __Klive__ supports:
 
 * __Full Z80 instruction set__, including the initially undocumented Z80 registers and instructions
 (such as the 8-bit halves of `ix` and `iy`, namely `ixl`, `ixh`, `iyl`, `iyh`).
@@ -24,13 +24,13 @@ declare a loop. All of the `.defb`, `DEFB`, `.db`, `DB` (and a few other) tokens
 byte data. The `.endw` and `WEND` tokens can close a WHILE-loop.
 * __Z80 Preprocessor__. With preprocessor directives, you can carry out conditional compilation and include
 other source files. You can inject symbols for debug time and run time compilations separately. *In __Klive__
-you can use powerful macros, too, notheless, they are not preprocessor constructs (see below)*.
+you can use powerful macros, too, nonetheless, they are not preprocessor constructs (see below)*.
 * __Fast compilation__. Of course, it depends on the code, but the compiler can emit code for about 8.000 
 source code lines per second.
 * __Rich expressions__. The compiler can handle most arithmetic and logic operators we have in C, C++, C#
 Java, and JavaScript. You can use integer, float, and string expressions. The language support more than 40
 functions that you can use in the expressions (e.g: `Amp * sin($cnt * Pi() / 16))`)
-* __Rich literal formats__. Decimal, float, hexadecimal, binary, and string literals are at your displosal.
+* __Rich literal formats__. Decimal, float, hexadecimal, binary, and string literals are at your disposal.
 You can use multiple variants for hexadecimal numbers (`$12ae`, #12AE, 0x12AE, 12AEh), and binary numbers
 (0b00111100, %00111100, %0011_1100). In strings, you can use ZX Spectrum specific escape codes, for example,
 `\i` for INK, `\P` for the pound sign, and many others.

--- a/docs/_posts/documents/2021-01-01-pragmas.md
+++ b/docs/_posts/documents/2021-01-01-pragmas.md
@@ -81,7 +81,7 @@ call MyCode
 ...
 ```
 
-The `.ent $` pragma will sign the address of the `jp #6100` isntruction as the entry
+The `.ent $` pragma will sign the address of the `jp #6100` instruction as the entry
 address of the code. Should you omit the __ENT__ pragma from this code, the entry point would be
 0x6200, for this is the start of the very first output segment, even though there is another
 segment starting at 0x6100.
@@ -294,7 +294,7 @@ an error message:
 ## The EQU pragma
 
 The __EQU__ pragma allows you assign a value to an identifier. The label before __EQU__ is the
-name of the identifier (or symbol), the exression used in __EQU__ is the value of the variable.
+name of the identifier (or symbol), the expression used in __EQU__ is the value of the variable.
 This is a short sample:
 
 ```
@@ -317,7 +317,7 @@ ld bc,#620a ; Sym2 <-- #620a as an ld bc,NNNN operation and
 ## The VAR pragma
 
 The __VAR__ pragma works similarly to __EQU__. However, while __EQU__ does not allow using the same symbol
-with mulitple value assignments, __VAR__ assigns a new value to the symbol every time it is used.
+with multiple value assignments, __VAR__ assigns a new value to the symbol every time it is used.
 
 > The VAR pragma accepts extra syntax alternatives: `=`, `:=`
 
@@ -368,14 +368,14 @@ This simple code above will emit these four bytes: 0x34, 0x12, 0xcd, 0xab.
 ## The DEFM pragma
 
 The __DEFM__ pragma emits the byte-array representation of a string. Each character
-in the string is replaced with the correcponding byte. Take a look at this code:
+in the string is replaced with the corresponding byte. Take a look at this code:
 
 ```
 .defm "\C by me"
 ```
 
 Here, the __DEFM__ pragma emits 7 bytes for the seven characters (the first escape 
-sequence represents the copyrigh sign) : 0x7f, 0x20, 0x62, 0x69, 0x20, 0x6d, 0x65.
+sequence represents the copyright sign) : 0x7f, 0x20, 0x62, 0x69, 0x20, 0x6d, 0x65.
 
 > __DEFM__ has extra syntax variants: `dm`, `.dm`, `DM`, and `.DM` are accepted, too.
 
@@ -389,7 +389,7 @@ byte to terminate the string. Look at this code:
 ```
 
 Here, the __DEFN__ pragma emits 8 bytes for the seven characters (the first escape 
-sequence represents the copyrigh sign) plus the terminating zero:
+sequence represents the copyright sign) plus the terminating zero:
 0x7f, 0x20, 0x62, 0x69, 0x20, 0x6d, 0x65, 0x00.
 
 > __DEFN__ has extra syntax variants: `dn`, `.dn`, `DN`, and `.DN` are also accepted.
@@ -404,7 +404,7 @@ emitted character. Look at this code:
 ```
 
 Here, the __DEFC__ pragma emits 7 bytes for the seven characters (the first escape 
-sequence represents the copyrigh sign) with Bit 7 of the last character (0x65) set (so it become 0xE5):
+sequence represents the copyright sign) with Bit 7 of the last character (0x65) set (so it become 0xE5):
 0x7f, 0x20, 0x62, 0x69, 0x20, 0x6d, 0xE5.
 
 > __DEFC__ has extra syntax variants: `dc`, `.dc`, `DC`, and `.DC` are also accepted.
@@ -413,7 +413,7 @@ sequence represents the copyrigh sign) with Bit 7 of the last character (0x65) s
 
 The __DEFH__ pragma uses a string with even number of hexadecimal digits to emits a 
 byte-array representation of the input. Each character pair in the string is replaced
-with the correcponding byte. Take a look at this code:
+with the corresponding byte. Take a look at this code:
 
 ```
 .defh "12E4afD2"
@@ -469,7 +469,7 @@ does not do any action when observing this pragma.
 ## The MODEL pragma
 
 This pragma is used when you run or debug your Z80 code within the emulator. With Spectrum 128K, Spectrum +3, 
-and Spectrum Next models, you can run the Z80 code in differend contexts. The __MODEL__ pragma lets you
+and Spectrum Next models, you can run the Z80 code in different contexts. The __MODEL__ pragma lets you
 specify on which model you want to run the code. You can use the `SPECTRUM48`, `SPECTRUM128`, 
 `SPECTRUMP3`, or `NEXT` identifiers to choose the model (identifiers are case-insensitive):
 
@@ -529,7 +529,7 @@ messages are displayed in the Z80 Build Output window pane. You can list one or 
 separated by a comma after the `.trace` token. TRACEHEX works just like TRACE, but id displays 
 integer numbers and strings in hexadecimal format.
 
-Let'assume, you add these lines to the source code:
+Let's assume, you add these lines to the source code:
 
 ```
 .trace "Hello, this is: ", 42
@@ -547,7 +547,7 @@ TRACE: 48656C6C6F2C20746869732069733A20002A
 
 With the `rnd()` function, you can generate random numbers. The RNDSEED pragma sets the seed
 value to use for random number generation. If you use this pragma with an integer expression,
-the seed is set to tha value of that expression. If you do not provide the expression, the compiler
+the seed is set to the value of that expression. If you do not provide the expression, the compiler
 uses the system clock to set up the seed.
 
 ```
@@ -611,7 +611,7 @@ Here are a few samples:
 .dg ....OO OO..OOOO ; #0F, #3C
 ```
 
-> Please note, unlinke in the pattern used with `DEFGX`, here, the leading `>` and `<` characters 
+> Please note, unlike in the pattern used with `DEFGX`, here, the leading `>` and `<` characters 
 > are taken as bit 1. They do not specify bit alignment.
 
 ## The ERROR Pragma
@@ -653,7 +653,7 @@ The three lines of code above are the same as if we had written these code lines
 .defb #02, #03, #04                          ; .includebin "./myfile.bin" 2, 3
 ```
 
-> Of course, the compiler does not allow negative file offset or length. It alse raises
+> Of course, the compiler does not allow negative file offset or length. It else raises
 > an error if you define a segment that does not fit into the binary file.  
 > You can use alternative syntax for `.includebin`. The compiler accepts these tokens and their
 > uppercase versions, too: `includebin`, `.include_bin`, and `include_bin`.

--- a/docs/_posts/documents/2021-01-01-statements.md
+++ b/docs/_posts/documents/2021-01-01-statements.md
@@ -260,9 +260,9 @@ This code translates to this:
 .db #23
 ```
 
-You can observe that each loop has its spearate `$cnt` value.
+You can observe that each loop has its separate `$cnt` value.
 
-> The `$ctn` value has several syntax versions that the compiler accepts: `$CNT`, 
+> The `$cnt` value has several syntax versions that the compiler accepts: `$CNT`, 
 > `.cnt`, and `.CNT`.
 
 ## The PROC..ENDP Block
@@ -313,7 +313,7 @@ MyEnd
 Outer    (#8018): nop
 ```
 
-You can nest `PROC` bloks just as `LOOP` blocks. Each `PROC` block has its private scope.
+You can nest `PROC` blocks just as `LOOP` blocks. Each `PROC` block has its private scope.
 When the compiler sees a `PROC` block, it works just as if you wrote `.loop 1`.
 
 > NOTE: `PROC` is different than a loop. You cannot use the `$cnt` value. Similarly, the `break` 
@@ -356,7 +356,7 @@ The `.repeat` block uses the same approach to handle its local scope, symbols, l
 variables as the `.loop` block. The block also provides the `$cnt` loop counter that starts 
 from 1 and increments in every loop cycle. 
 
-This sample demontrates the `.repeat` block in action:
+This sample demonstrates the `.repeat` block in action:
 
 ```
 .org #8000
@@ -443,7 +443,7 @@ The compiler translates the code to this:
 
 ## The FOR..NEXT Loop
 
-Tou can use the traditional `.for`..`.next` loop to create a loop:
+You can use the traditional `.for`..`.next` loop to create a loop:
 
 ```
 .for myVar = 2 .to 5
@@ -546,7 +546,7 @@ Nonetheless, you can solve this issue with applying the `int()` function:
 ```
 
 > You can still use the `$cnt` value in for loops. Just like with other loop, it indicates the count of
-> cycles strating from one and incremented by one in each iteration.
+> cycles starting from one and incremented by one in each iteration.
 
 ## Maximum Loop Count
 

--- a/docs/_posts/documents/2021-01-01-structs.md
+++ b/docs/_posts/documents/2021-01-01-structs.md
@@ -282,7 +282,7 @@ Obj6: Object2D()
 
 ## Fluent Structure Initialization
 
-The assembler allows using flexible initialization, where you do not use field names. The compiler amits bytes as the byte emitter pragmas would do if you were not within a structure initialization. Let's assume, you initialize an `Object2D` this way:
+The assembler allows using flexible initialization, where you do not use field names. The compiler emits bytes as the byte emitter pragmas would do if you were not within a structure initialization. Let's assume, you initialize an `Object2D` this way:
 
 ```
 Obj7: Object2D()

--- a/docs/_posts/documents/2021-01-01-z80-instructions.md
+++ b/docs/_posts/documents/2021-01-01-z80-instructions.md
@@ -78,7 +78,7 @@ adc a,(hl)
 sbc a,e
 ```
 
-Hovewer, the five other standard ALU operations between `A` and other operands (`SUB`, `AND`, `XOR`, 
+However, the five other standard ALU operations between `A` and other operands (`SUB`, `AND`, `XOR`, 
 `OR`, and `CP`) omit `A` from their notation:
 
 ```

--- a/docs/_posts/getting-started/2020-08-01-use-the-emulator.md
+++ b/docs/_posts/getting-started/2020-08-01-use-the-emulator.md
@@ -60,7 +60,7 @@ Klive allows you a few things with the virtual retro computer that you cannot do
 
 > *Note*: As a reference, my computer has an AMD Ryzen 7 2700 CPU with 3.2GHz and 16GB RAM. This configuration allows running ZX Spectrum with the 24 clock multiplier.
 
-Though the clock multiplier function increases the CPU speed, it does not affect other hardware components. For example, when you run ZX Spectrum 48 with an increased CPU clock, the ULA still uses 14 Mhz as its clock frequency.
+Though the clock multiplier function increases the CPU speed, it does not affect other hardware components. For example, when you run ZX Spectrum 48 with an increased CPU clock, the ULA still uses 14 MHz as its clock frequency.
 
 > *Note*: When the status bar is on, it displays the emulated clock frequency using the base frequency and the selected multiplier.
 
@@ -72,7 +72,7 @@ You can use the virtual keyboard to emulate keystrokes and keypresses. When you 
 
 To press a key, move the mouse over one of the virtual keys, and click it. If you keep the mouse button down, it's just like keeping the button pressed. Releasing the mouse button behaves as you released the real key.
 
-To press a key, move the mouse over one of the virtual keys, and click it. If you keep the mouse button down, it's just like keeping the button pressed. Releasing the mouse button behaves as you released the real key. As the following figures show, a single key provides multiple options according to the area ok the button you point with the mouse. You can use both the left and right mouse buttons. However, when using the right mouse button, the key behaves as if you pressed the **SYMBOL SHIFT** button simultaneously.
+To press a key, move the mouse over one of the virtual keys, and click it. If you keep the mouse button down, it's just like keeping the button pressed. Releasing the mouse button behaves as you released the real key. As the following figures show, a single key provides multiple options according to the area of the button you point with the mouse. You can use both the left and right mouse buttons. However, when using the right mouse button, the key behaves as if you pressed the **SYMBOL SHIFT** button simultaneously.
 
 ![Z80 code]({{ site.baseurl }}/assets/images/tutorials/main-key.png)
 ![Z80 code]({{ site.baseurl }}/assets/images/tutorials/sym-key.png)

--- a/docs/_posts/spectrum/2019-01-01-basic-appc1.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-appc1.md
@@ -14,7 +14,7 @@ The first section of this appendix is a repeat of that part of the Introduction 
 ## The keyboard
 
 ZX Spectrum characters comprise not only the single symbols (letters, digits, etc), but also the compound tokens (keywords, function names, etc) and all these
-are entered trom the keyboard rather than being spelled out. To obtain all these functions and commands some keys have five or more distinct meanings, given
+are entered from the keyboard rather than being spelled out. To obtain all these functions and commands some keys have five or more distinct meanings, given
 partly by shifting the keys (i.e. pressing either the **CAPS SHIFT** key or the **SYMBOL SHIFT** key at the same time as the required one) and partly by having the machine in different modes.
 
 The mode is indicated by the cursor, a flashing letter that shows where the next character from the keyboard will be inserted.
@@ -70,8 +70,8 @@ The edge of the screen can be set to any of the colours using the border stateme
 A character position is divided into 8x8 pixels and high resolution graphics are obtained by setting the pixels individually to show either the ink or paper
 colour for that character position.
 
-The attributes at a character position are adjusted whenever a character is written there or a pixel is plotted The exact manner of the adjustment is
-determined by the pnnting parameters. of which there are two sets (called permanent and temporary) of six: the **PAPER**, **INK**, **FLASH**, **BRIGHT**, **INVERSE** and **OVER** parameters. Permanent parameters for the top part are set up by **PAPER**, **INK**, etc, statements, and last until further notice. (Initially they are black ink on white paper. With normal brightness, no flashing, normal video and no overprinting). Permanent parameters for the bottom part use the border colour as the paper colour, with a black or white contrasting ink colour, normal brightness, no flashing, normal video and no overprinting.
+The attributes at a character position are adjusted whenever a character is written there or a pixel is plotted. The exact manner of the adjustment is
+determined by the painting parameters; of which there are two sets (called permanent and temporary) of six: the **PAPER**, **INK**, **FLASH**, **BRIGHT**, **INVERSE** and **OVER** parameters. Permanent parameters for the top part are set up by **PAPER**, **INK**, etc, statements, and last until further notice. (Initially they are black ink on white paper. With normal brightness, no flashing, normal video and no overprinting). Permanent parameters for the bottom part use the border colour as the paper colour, with a black or white contrasting ink colour, normal brightness, no flashing, normal video and no overprinting.
 
 Temporary parameters are set up by **PAPER**, **INK**, etc, items, which are embedded in **PRINT**, **LPRINT**, **INPUT**, **PLOT**, **DRAW** and **CIRCLE** statements, and also by **PAPER**, **INK**, etc control characters when they are printed to the television - they are followed by a further byte to specify the parameter value. Temporary parameters last only to the end of the **PRINT** (or whatever) statement, or, in **INPUT** statements, until some INPUT data is needed from the keyboard, when they are replaced by the permanent parameters.
 
@@ -119,9 +119,9 @@ received, the printing position is moved on to the next line.
 
 Output to the ZX printer is via a buffer one line (32 characters) long, and a line is sent to the printer
  
-_(i)_ when printing spills over from one line to the next,  
+_(i)_ when printing spills over from one line to the next,
 _(ii)_ when an ENTER character is received,  
-_(iii)_ at the end of the program, if there is anything left unprinted,  
+_(iii)_ at the end of the program, if there is anything left unprinted,
 _(iv)_ when a **TAB** control or comma control moves the printing position on to a new line.
 
 **TAB** controls and comma controls output spaces in the same way as on the television.

--- a/docs/_posts/spectrum/2019-01-01-basic-appc2.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-appc2.md
@@ -18,7 +18,7 @@ the number m*2e<sup>-128</sup>
 Since ½<=m<l, the most significant bit of the mantissa m is always 1. Therefore in actual fact we can replace it with a bit to show the sign - 0 for
 positive numbers, 1 for negative.
 
-Small integers have a special representation in which the first byte is 0, thesecond is a sign byte (0 or FFh) and the third and fourth are the integer in
+Small integers have a special representation in which the first byte is 0, the second is a sign byte (0 or FFh) and the third and fourth are the integer in
 twos complement form, the less significant byte first.
 
 Numeric variables have names of arbitrary length, starting with a letter and continuing with letters and digits. Spaces and colour controls are ignored and
@@ -98,27 +98,27 @@ The argument of a function does not need brackets if it is a constant or a (poss
 |**TAN**|number(in radians)|Tangent|
 |**USR**|number|Calls the machine code subroutine whose starting address is x. On return, the result is the contents of the bc register pair|
 |**USR**|string|The address of the bit pattern for user-defined graphic corresponding to x. Error A if x is not a single letter between a and u, or a user-defined graphic|
-|**VAL**|string|Evaluates x (without its boundingquotes) as a numerical expression. Error C if x contains a syntax error, or gives a string value. Other errors possible, depending on the expression|
+|**VAL**|string|Evaluates x (without its bounding quotes) as a numerical expression. Error C if x contains a syntax error, or gives a string value. Other errors possible, depending on the expression|
 |**VAL$**|string|Evaluates x (without its bounding quotes) as a string expression. Error C if x contains a syntax error or gives a numeric value. Other errors possible, as for VAL|
 |**-**|number|Negation|
 
 The following are binary operations
 
-|Operator| Explantion | Additional info|
+|Operator| Explanation | Additional info|
 |---|---|---|
 |+|Addition (on numbers), or concatenation (on strings)|
 |-|Subtraction|
 |*|Multiplication| 
 |/|Division|
 |^|Raising to a power. Error B if the left operand is negative|
-|=|Equals|Both operands must be of the same type. The result is a number 1, if the mparison holds and 0 if it does not|
+|=|Equals|Both operands must be of the same type. The result is a number 1, if the comparison holds and 0 if it does not|
 |>|Greater than|  ''             ''|
 |<|Less than|  ''             ''|
 |<=|Less than or equal to|  ''             ''|
 |>=|Greater than or equal to|  ''             ''|
 |<>|Not equal to|  ''             ''|
 
-Functions and opertions have the following priorities
+Functions and operations have the following priorities
 
 |Operation|Priority|
 |---|---|
@@ -155,7 +155,7 @@ All statements except **INPUT**, DEF and **DATA** can be used either as commands
 
 | Statement | Explanation |
 |:----------|---|
-|**BEEP** |x, y Sounds a note through the loudspeaker for x seconds ata pitch y semitones above middle C (or below if y is negative).
+|**BEEP** |x, y Sounds a note through the loudspeaker for x seconds at a pitch y semitones above middle C (or below if y is negative).
 |**BORDER** m |Sets the colour of the border of the screen and also the paper colour for the lower part of the screen. Error K is m not in the range 0 to 7.
 |**BRIGHT** |Sets brightness of characters subsequently printed. n=0 for normal, 1 for bright. 8 for transparent. Error K if n not 0, 1 or 8
 |**CAT** |Does not work without Microdrive, etc

--- a/docs/_posts/spectrum/2019-01-01-basic-ch10.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch10.md
@@ -151,7 +151,7 @@ Another property is that once *a* has got up to 2&pi;, the point is back where i
 
 The *tangent* of *a* is defined to be the sine divided by the cosine; the corresponding function on the computer is called **TAN**.
 
-Sometimes we need to work these functions out in reverse, finding the value of a that has given sine, cosine or tangent. The furctions to do this are called
+Sometimes we need to work these functions out in reverse, finding the value of a that has given sine, cosine or tangent. The functions to do this are called
 *arcsine* (**ASN** on the computer), *arccosine* (**ACS**) and *arctangent* (**ATN**).
 
 In the diagram of the point moving round the circle, look at the radius joining the centre to the point. You should be able to see that the distance we have

--- a/docs/_posts/spectrum/2019-01-01-basic-ch13.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch13.md
@@ -85,7 +85,7 @@ for '1<>2', which is true.
 
 _(ii)_ In **IF** condition **THEN** . . .
 
-the condition can be actually any numeric expression. If its value is 0, then it counts as false, and any other value lincluding the value of 1 that a true
+the condition can be actually any numeric expression. If its value is 0, then it counts as false, and any other value including the value of 1 that a true
 relation gives) counts as true. Thus the **IF** statement means exactly the same as **IF** condition **<>0 THEN** . . .
 
 _(iii)_: **AND**, **OR** and **NOT** are also number-valued operations.

--- a/docs/_posts/spectrum/2019-01-01-basic-ch14.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch14.md
@@ -26,7 +26,7 @@ there are two functions, **CODE** and **CHR$**.
 
 **CODE** is applied to a string, and gives the code of the first character in the string (or 0 if the string is empty).
 
-**CHR$** is applied to a number, and gives the single character string whosecode is that number.
+**CHR$** is applied to a number, and gives the single character string whose code is that number.
 
 This program prints out the entire character set:
 
@@ -95,7 +95,7 @@ Even if you don't understand this, the following program will do it for you:
 30 NEXT n
 ```
 
-It will stop for **INPUT** data eight times to ailow you to type in the eight BIN numbers above - type them in the right order, starting with the top row.
+It will stop for **INPUT** data eight times to allow you to type in the eight BIN numbers above - type them in the right order, starting with the top row.
 
 The **POKE** statement stores a number directly in memory location, bypassing the mechanisms normally used by the BASIC. The opposite of **POKE** is **PEEK**, and this allows us to look at the contents of a memory location although it does not actually alter the contents of that location. They will be dealt with properly in Chapter 24.
 
@@ -107,7 +107,7 @@ prints ? to show that it doesn't understand them. They are described more fully 
 
 Three that the television uses are those with codes 6, 8 and 13; on the whole, **CHR$** 8 is the only one you are likely to find useful.
 
-**CHR$** 6 prints spaces in exactly the same way as a cornma does in a **PRINT** statement for instance
+**CHR$** 6 prints spaces in exactly the same way as a comma does in a **PRINT** statement for instance
 
 ```
 PRINT 1; **CHR$** 6;2

--- a/docs/_posts/spectrum/2019-01-01-basic-ch15.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch15.md
@@ -74,7 +74,7 @@ that after having carefully set up the **PRINT** position you immediately move i
 
 _(ii)_: You cannot print on the bottom two lines (22 and 23) on the screen because they are reserved for commands, **INPUT** data, reports and so on. References to 'the bottom line' usually mean line 21.
 
-_(iii)_: You can use **AT** to put the **PRINT** position even where there is alreadysomething printed; the old stuff will be obliterated when you print more.
+_(iii)_: You can use **AT** to put the **PRINT** position even where there is already something printed; the old stuff will be obliterated when you print more.
 
 Another statement connected with **PRINT** is **CLS**. This clears the whole screen, something that is also done by **CLEAR** and **RUN**.
 

--- a/docs/_posts/spectrum/2019-01-01-basic-ch16.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch16.md
@@ -272,7 +272,7 @@ type
 PRINT CHR$ 8; OVER 1;"r'
 ``` 
 
-why do vou recover an unblemished B?
+why do you recover an unblemished B?
  
 ``` 
 PAPER 0: INK 0

--- a/docs/_posts/spectrum/2019-01-01-basic-ch18.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch18.md
@@ -22,7 +22,7 @@ Quite often you will want to make the program take a specified length of time, a
 stops computing and displays the picture for *n* frames of the television (at 50 frames per second in Europe or 60 in America). *n* can be up to 65535, which
 gives you just under 22 minutes; if *n*=0 then it means '**PAUSE** for ever'.
 
-A pause can always be cut short by pressing a key (note that a CAPS SHlFTed space will cause a break as well). You have to press the key down after the
+A pause can always be cut short by pressing a key (note that a CAPS SHIFTed space will cause a break as well). You have to press the key down after the
 pause has started.
 
 This program works the second hand of a clock
@@ -73,7 +73,7 @@ REM number of seconds since start
 230 LET t1=t: GO TO 120
 ```
 
-The internal clock that this methcd uses should be accurate to about .01% as long as the computer is just running its program, or 10 seconds per day; but it
+The internal clock that this method uses should be accurate to about .01% as long as the computer is just running its program, or 10 seconds per day; but it
 stops temporarily whenever you do **BEEP**, or a cassette tape operation, or use the printer or any of the other extra pieces of equipment you can use with the
 computer. All these will make it lose time.
 

--- a/docs/_posts/spectrum/2019-01-01-basic-ch20.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch20.md
@@ -17,7 +17,7 @@ permalink: "spectrum/basic-ch20"
 
 The basic method for using the cassette recorder to **SAVE**, **LOAD** and **VERIFY** programs are given in the Introductory booklet. This section should be read, and the procedures tried out before reading any further. 
 
-We have seen that **LOAD** deletes the old program and variables in the computer before loading in the new ones from tape; there is another, **MERGE**, that does not. MERGE only deletes an old program line or variable if it has to because there is a new one with the same line number or name. Type inthe 'dice' program in Chapter 11 and save it on tape, as "dice". Now enter and run the following: 
+We have seen that **LOAD** deletes the old program and variables in the computer before loading in the new ones from tape; there is another, **MERGE**, that does not. MERGE only deletes an old program line or variable if it has to because there is a new one with the same line number or name. Type in the 'dice' program in Chapter 11 and save it on tape, as "dice". Now enter and run the following: 
 
 ```
 1 PRINT 1
@@ -30,7 +30,7 @@ and then proceed as for the verification, but replacing **VERIFY "dice"** with
 	****MERGE** "dice"**
 
 
-If you list the program you can see that lines 1 and 2 have survived, but lines 10 and 20 have been replaced by those from the dice program. x has also survuved (try PRINT x). 
+If you list the program you can see that lines 1 and 2 have survived, but lines 10 and 20 have been replaced by those from the dice program. x has also survived (try PRINT x). 
 
 You have now seen simple forms of the four statements used with the cassette tape: 
 
@@ -42,7 +42,7 @@ You have now seen simple forms of the four statements used with the cassette tap
 
 **MERGE** is like **LOAD** except that it does not clear out an old program line or variable unless it has to because its line number or name is the same as that as that of a new one from cassette. 
 
-In each of these, the keyword is followed by a string: for **SAVE** this provides a name for the program on tape, while for the other three it tells the computer which program to search for. While it is searching, it prints up the name of each program it comes across. There are a coupl of twists to all this. 
+In each of these, the keyword is followed by a string: for **SAVE** this provides a name for the program on tape, while for the other three it tells the computer which program to search for. While it is searching, it prints up the name of each program it comes across. There are a couple of twists to all this. 
 
 For **VERIFY**, **LOAD** and **MERGE** you can provide the empty string as the name to search for; then the computer does not care about the name, but takes the first program it comes across. 
 
@@ -50,11 +50,11 @@ A variant on **SAVE** takes the form **SAVE** string LINE number
  
 A program saved using this is recorded in such a way that when it is read back by **LOAD** (but not **MERGE**) it automatically jumps to the line with the given number, thus running itself. 
 
-So far, the only kins of information we have stored on cassette have been programs together with their variables. There are two other kinds as well, called arrays and bytes. 
+So far, the only kind of information we have stored on cassette have been programs together with their variables. There are two other kinds as well, called arrays and bytes. 
 
 Arrays are dealt with slightly differently: 
 
-You can save arrayson tape using **DATA** in a **SAVE** statement by 
+You can save arrays on tape using **DATA** in a **SAVE** statement by 
 
 **SAVE string DATA arrayname()**
 
@@ -62,7 +62,7 @@ String is the name that the information will have on tape and works in exactly t
 
 The array name specifies the array you want to save, so it is just a letter or a letter followed by $. Remember the brackets afterwards; you might think they are logically unnecessary but you still have to put them in to make it easier for the computer. 
 
-Be cleaar about the separate roles of string and array name. If you say (for instance) 
+Be clear about the separate roles of string and array name. If you say (for instance) 
 SAVE "Bloggs" **DATA b()**
 
 then **SAVE** takes the array b from the computer ans stores it on tape under the name "Bloggs". When you type 
@@ -72,7 +72,7 @@ the computer will look for a number array stored on tape under the name "Bloggs"
 
 **LOAD** "Bloggs" **DATA b()**
 
-finds the array on tape, and then - if there is room for it in the computer - delete any array already existing called b and loads in the new arrat from tape, calling it b. 
+finds the array on tape, and then - if there is room for it in the computer - delete any array already existing called b and loads in the new array from tape, calling it b. 
 
 You cannot use **MERGE** with saved arrays.
 
@@ -92,9 +92,9 @@ You can put numbers after **CODE** in the form
 
 **LOAD** name **CODE** start,length
 
-Here length is just a safety measure; wjen the computer has found the bytes on taoe with the right name, it will still refuse to load them in if there are more than length of them - since there is obviously more data than you expected it could otherwise overwrite something you had not intended to be overwritten. It gives the error report **R Tape loading error**. You can miss out length, and then the computer will read in the bytes however many there are. 
+Here length is just a safety measure; when the computer has found the bytes on tape with the right name, it will still refuse to load them in if there are more than length of them - since there is obviously more data than you expected it could otherwise overwrite something you had not intended to be overwritten. It gives the error report **R Tape loading error**. You can miss out length, and then the computer will read in the bytes however many there are. 
 
-Start shows the addreswhere the first byte is to be loaded back to - thuis can be different frmo the address it was saved from, although if they are the same you can miss out the start in the **LOAD** statement. 
+Start shows the address where the first byte is to be loaded back to - this can be different from the address it was saved from, although if they are the same you can miss out the start in the **LOAD** statement. 
 
 **CODE** 16384,6912 is so useful for saving and loading the picture that you can replace it with SCREEN$ - for instance. 
 
@@ -104,19 +104,19 @@ Start shows the addreswhere the first byte is to be loaded back to - thuis can b
 
 This is a rare case for which **VERIFY** will not work &mdash; **VERIFY** writes up the names of what it finds on tape, so that by the time it gets round to the verification the display file has been changed and the verification fails. In all other cases you should use **VERIFY** whenever you use **SAVE**. 
 
-Below, is a complete summary of the four statemnts used in this chapter. 
+Below, is a complete summary of the four statements used in this chapter. 
 
-Name stands for any string expression, and refers to the name under which the information is stored on cassette. It should consistof ASCII printing chracters, of which only the first 10 are used. 
+Name stands for any string expression, and refers to the name under which the information is stored on cassette. It should consist of ASCII printing characters, of which only the first 10 are used. 
 
 There are four sorts of information that can be stored on tape: program and variables (together), number arrays, character arrays and straight bytes. 
 
-When **VERIFY**, **LOAD** and **MERGE** are searching the tape for information with a given name and of a given sort, they print up on the screen the sort and name of all the information they fnid. The sort is shown by 'Program:', 'Number array:', 'Character arrat:' or 'Bytes:'. If name was the empty stringm they take the first lot if information of the right sort, regardless of its name. 
+When **VERIFY**, **LOAD** and **MERGE** are searching the tape for information with a given name and of a given sort, they print up on the screen the sort and name of all the information they find. The sort is shown by 'Program:', 'Number array:', 'Character array:' or 'Bytes:'. If name was the empty string they take the first lot if information of the right sort, regardless of its name. 
 
 **SAVE**
 
 Saves information on tape under the given name. Error F occurs when name is empty or has 11 or more characters. 
 
-**SAVE** always puts up a messaeg Start tape, then press any key, and waits for a key to be pressed before saving anything.
+**SAVE** always puts up a message Start tape, then press any key, and waits for a key to be pressed before saving anything.
 
 1. Program and variables: 
 **SAVE** name LINE line number
@@ -161,7 +161,7 @@ Checks the information against on tape against the information already in memory
 
 **LOAD**
 
-Loads new information fron tape, deleting old information from memory. 
+Loads new information from tape, deleting old information from memory. 
 1. Program and variables. 
 **LOAD** name
  deletes the old program and variables and loads in program and variables name from cassette; if the program was saved using **SAVE** name LINE it performs an automatic jump. 
@@ -189,7 +189,7 @@ Error **4 out of memory** occurs if no room for new arrays. Old arrays are not d
 
 **MERGE**
 
-Loads new information from cassette without deleteing old information from memory. 
+Loads new information from cassette without deleting old information from memory. 
 
 1. Program and variables: 
 **MERGE** name
@@ -204,8 +204,8 @@ Not possible
 
 ## Exercises
 
-1. Make a cassette on which the first program, when loaded, prints a menu ( alist of the other programs on the cassette), asks you to choose a program, and then loads it.
-2. Get the chess piece graphics from Chapter 14, and then type **NEW**: they will survive this. However, they will not survive having the computer turned off; if you want to keep then, you mst save them on tape, using **SAVE** with **CODE**. The easiest way is to save all twenty-one user defined graphics by 
+1. Make a cassette on which the first program, when loaded, prints a menu (a list of the other programs on the cassette), asks you to choose a program, and then loads it.
+2. Get the chess piece graphics from Chapter 14, and then type **NEW**: they will survive this. However, they will not survive having the computer turned off; if you want to keep then, you must save them on tape, using **SAVE** with **CODE**. The easiest way is to save all twenty-one user defined graphics by 
 
 **SAVE** "chess" **CODE** **USR** "a",21*8
 
@@ -213,11 +213,11 @@ followed by
 
 **VERIFY** "chess" **CODE**
 
-This is the system of bytes saving that was used for saving the picture. The address of the first byte to be saved is **USR** "a", the address of the first of the eight bytes that determine the pattern of the first user-defined grpahics, and the number of bytes to be saves is 21*8 - eight bytes for each of 21 graphics. 
+This is the system of bytes saving that was used for saving the picture. The address of the first byte to be saved is **USR** "a", the address of the first of the eight bytes that determine the pattern of the first user-defined graphics, and the number of bytes to be saves is 21*8 - eight bytes for each of 21 graphics. 
 
 To load back you would normally use **LOAD** "chess" **CODE** 
 
-However, if you are loading back into a Spectrum with a different amount of memory, or if you have moved the user-defined graphics to a different address (you have to do this deliberately using more advanced techniques), you hav to be more careful and use 
+However, if you are loading back into a Spectrum with a different amount of memory, or if you have moved the user-defined graphics to a different address (you have to do this deliberately using more advanced techniques), you have to be more careful and use 
 
 **LOAD** "chess" **CODE** **USR** "a" 
 

--- a/docs/_posts/spectrum/2019-01-01-basic-ch23.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch23.md
@@ -43,7 +43,7 @@ The byte read or written has 8 bits, and these are often referred to (using D fo
 
 There is a set of input addresses that read the keyboard and also the EAR socket.
 
-The keyboard is dividecl up into 8 half rows of 5 keys each.
+The keyboard is divided up into 8 half rows of 5 keys each.
 
 **IN 65278** reads the half row **CAPS SHIFT** to **V**
 

--- a/docs/_posts/spectrum/2019-01-01-basic-ch24.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch24.md
@@ -36,7 +36,7 @@ prints out the first 21 bytes in ROM (and their addresses):
 40 NEXT a
 ```
 
-All these bytes will probably be quite meaningless to you, but the processor chip understands them to be instuctions telling it what to do.
+All these bytes will probably be quite meaningless to you, but the processor chip understands them to be instructions telling it what to do.
 
 To change the contents of a box (if it is RAM), we use the **POKE** statement. It has the form
 

--- a/docs/_posts/spectrum/2019-01-01-basic-ch25.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch25.md
@@ -22,9 +22,9 @@ referring to system variables, and they are given solely as mnemonics for we hum
 **N** Poking the variable will have no lasting effect
 
 The number in column 1 is the number of bytes in the variable. For two bytes, the first one is the less significant byte the reverse of what you might expect.
-So to poke a value **v** to a two byte variable at address **n**, use **POKE n,v-256\*1NT (v/256)**
+So to poke a value **v** to a two byte variable at address **n**, use **POKE n,v-256\*INT (v/256)**
 
-**POKE n+1,lNT (v/256)**
+**POKE n+1,INT (v/256)**
 
 and to peek its value, use the expression
 
@@ -34,12 +34,12 @@ and to peek its value, use the expression
 |Notes|Address|Name|Contents|
 |---|----|---|---|
 |N8|23552|KSTATE|Used in reading the keyboard.|
-|Nl|23560|LAST K|Stores newly pressed key.|
+|N1|23560|LAST K|Stores newly pressed key.|
 |1|23561|REPDEL|Time (in 50ths of a second in 60ths of a second in N. America) that a key must be held down before it repeats. This starts off at 35, but you can POKE in other values.|
 |1|23562|REPPER|Delay (in 50ths of a second in 60ths of a second in N. America) between successive repeats of a key held down: initially 5.|
 |N2|23563|DEFADD|Address of arguments of user defined function if one is being evaluated; otherwise 0.|
-|Nl|23565|K DATA|Stores 2nd byte of colour controls entered from keyboard .|
-|N2|23566|TVDATA|Stores bytes of coiour, AT and TAB controls going to television.|
+|N1|23565|K DATA|Stores 2nd byte of colour controls entered from keyboard .|
+|N2|23566|TVDATA|Stores bytes of colour, AT and TAB controls going to television.|
 |X38|23568|STRMS|Addresses of channels attached to streams.|
 |2|23606|CHARS|256 less than address of character set (which starts with space and carries on to the copyright symbol). Normally in ROM, but you can set up your own in RAM and make CHARS point to it.|
 |1|23608|RASP|Length of warning buzz.|

--- a/docs/_posts/spectrum/2019-01-01-basic-ch3.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch3.md
@@ -63,7 +63,7 @@ are false.
 
 Line 40 compares **a** and **b**. If they are equal then the program is halted by the **STOP** command. The report at the bottom of the screen **9 STOP, statement, 30:3** shows that the third statement, or command, in line 30 caused the program to halt, i.e. **STOP**.
 
-Line 50 determines whether **b** is less than **a**, and line 60 whether **b** is greater than **a**. If one of these conditions is true then the appropriate comment is printed, and the program works its way to line 70 which tellsthe computer to go back to line 30 and start all over again.
+Line 50 determines whether **b** is less than **a**, and line 60 whether **b** is greater than **a**. If one of these conditions is true then the appropriate comment is printed, and the program works its way to line 70 which tells the computer to go back to line 30 and start all over again.
 
 The **CLS**, clear screen, command in line 20 was to stop the other person seeing what you put in.
 

--- a/docs/_posts/spectrum/2019-01-01-basic-ch4.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch4.md
@@ -128,7 +128,7 @@ FOR m=0 TO 10: PRINT m: NEXT m
 ```
 
 You can sometimes use this as a (somewhat artificial) way of getting round the restriction that you cannot **GO TO** anywhere inside a command - because a command
-has no line nurrber. For instance,
+has no line number. For instance,
 
 ```
 FOR m=0 TO 1 STEP 0: INPUT a: PRINT a: NEXT m

--- a/docs/_posts/spectrum/2019-01-01-basic-ch5.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch5.md
@@ -24,7 +24,7 @@ To do this, you use the statements **GO SUB** (GO to SUBroutine) and **RETURN**.
 **GO SUB** n
 
 where n is the line number of the first line in the subroutine. It is just like **GO TO** n except that the computer remembers where the **GO SUB** statement was so that it can come back again after doing the subroutine. It does this by putting the line number and the statement number within the line (together these
-constitute the retum address) on top of a pile of them (the **GO SUB** stack);
+constitute the return address) on top of a pile of them (the **GO SUB** stack);
 
 **RETURN**
 

--- a/docs/_posts/spectrum/2019-01-01-basic-ch7.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch7.md
@@ -104,7 +104,7 @@ and so on.
 This proves that the computer can hold the digits of 4294967295, even though it is not prepared to display them all at once.
 
 The ZX Spectrum uses floating point arithmetic, which means that it keeps separate the digits of a number (its mantissa) and the position of the point
-(the exponentt. This is not always exact, even for whole numbers. Type
+(the exponent. This is not always exact, even for whole numbers. Type
 
 **PRINT 1e10+1-1e10,1e10-1e10+1**
 

--- a/docs/_posts/spectrum/2019-01-01-basic-ch9.md
+++ b/docs/_posts/spectrum/2019-01-01-basic-ch9.md
@@ -196,7 +196,7 @@ get to line 40. They do, however, have to be somewhere in the program. They can'
 Third, x and y are both the names of variables in the program as a whole, and the names of arguments for the function FN p. FN p temporarily forgets about the
 variables called x and y, but since it has no argument called a, it still remembers the variable a. Thus when FN p(2,3) is being evaluated, a has the
 value 10 because it is the variable, x has the value 2 because it is the first argument, and y has the value 3 because it is the second argument. The result is
-then, 10+2\*3=16. When FN q() is beinq evaluated, on the other hand. there are no arauments. so a. x and v all still refer to the variables and have values 10,
+then, 10+2\*3=16. When FN q() is being evaluated, on the other hand. there are no arguments. so a. x and v all still refer to the variables and have values 10,
 0 and 0 respectively. The answer in this case is 10+0\*0=10.
 
 Now change line 20 to


### PR DESCRIPTION
I got tired eyeballing everything in order to find some typos beyond what I have noticed while was reading through topics of interest; So I have put the whole markdown content through a utility called [_aspell_](http://aspell.net/). This also revealed a few OCR errors along the way.