### PR TITLE
fix: an unexpected ERROR Z0605 when initializing a struct

### DIFF
--- a/src/main/z80-compiler/assembler.ts
+++ b/src/main/z80-compiler/assembler.ts
@@ -1087,6 +1087,7 @@ export class Z80Assembler extends ExpressionEvaluator {
           this._overflowLabelLine = null;
         }
       }
+      const isFieldAssignment = asmLine.type === "FieldAssignment";
       // --- Check if there's a label to create
       if (currentLabel) {
         // --- There's a label, we clear the previous hanging label
@@ -1097,7 +1098,11 @@ export class Z80Assembler extends ExpressionEvaluator {
           !(
             isLabelSetter(asmLine) ||
             this._isInStructCloning ||
-            (isByteEmittingPragma(asmLine) && this._currentStructInvocation)
+            (
+              isFieldAssignment && 
+              isByteEmittingPragma(asmLine) &&
+              this._currentStructInvocation
+            )
           )
         ) {
           if (
@@ -1136,7 +1141,6 @@ export class Z80Assembler extends ExpressionEvaluator {
       }
 
       // --- Handle field assignment statement
-      const isFieldAssignment = asmLine.type === "FieldAssignment";
       if (isFieldAssignment) {
         asmLine = (asmLine as unknown as FieldAssignment)
           .assignment as unknown as Z80AssemblyLine;

--- a/test/assembler/struct-regression.test.ts
+++ b/test/assembler/struct-regression.test.ts
@@ -17,4 +17,35 @@ describe("Assembler - struct invocation regression", () => {
       SnakeHead: Point2d()
     `, 0x21, 0x06, 0x80, 0x21, 0x07, 0x80, 0x00, 0x00);
   });
+
+  it("Struct regression issue (ID casing) #2", async () => {
+    await testCodeEmit(`
+      Point2d:
+      .struct
+        X: .db 0
+        Y: .db 0
+      .ends
+
+      ld hl,ThisShouldNotFail
+
+      SnakeHead: Point2d()
+      ThisShouldNotFail: .db #55
+    `, 0x21, 0x05, 0x80, 0x00, 0x00, 0x55);
+  });
+
+  it("Struct regression issue (ID casing) #2a", async () => {
+    await testCodeEmit(`
+      Point2d:
+      .struct
+        X: .db 0
+        Y: .db 0
+      .ends
+
+      ld hl,ThisShouldNotFail
+
+      SnakeHead: Point2d()
+        -> .dw 0xBEEF
+      ThisShouldNotFail: .db #55
+    `, 0x21, 0x05, 0x80, 0xEF, 0xBE, 0x55);
+  });
 });


### PR DESCRIPTION
The case is that the struct initialization expression 'eats up' the following label declaration; or vice versa the declared label never makes it into symbols table when preceded with a struct initialization.

The code like this:
```
  ld hl,ThisShouldNotFail
  SnakeHead: Point2d()
  ThisShouldNotFail: .db #55
```
won't compile without this change.

But, after reading [the docs](https://dotneteer.github.io/kliveide/documents/structs#article) one may find this behaviour surprising. 

Well, this one PR I am not too confident about. At least it pass tests successfully.