### PR TITLE
Fix/assembler strikes back

### DIFF
--- a/src/main/z80-compiler/assembler.ts
+++ b/src/main/z80-compiler/assembler.ts
@@ -1833,7 +1833,7 @@ export class Z80Assembler extends ExpressionEvaluator {
 
     let currentAddr = this.getCurrentAssemblyAddress();
     if (skipAddr.value < currentAddr) {
-      this.reportAssemblyError("Z0313", pragma, null, skipAddr, currentAddr);
+      this.reportAssemblyError("Z0313", pragma, null, skipAddr.value, currentAddr);
       return;
     }
     var fillByte = 0xff;

--- a/src/main/z80-compiler/assembler.ts
+++ b/src/main/z80-compiler/assembler.ts
@@ -1099,7 +1099,7 @@ export class Z80Assembler extends ExpressionEvaluator {
             isLabelSetter(asmLine) ||
             this._isInStructCloning ||
             (
-              (isFieldAssignment || 
+              (isFieldAssignment &&
               isByteEmittingPragma(asmLine)) &&
               this._currentStructInvocation
             )
@@ -1112,11 +1112,13 @@ export class Z80Assembler extends ExpressionEvaluator {
             // --- Check if temporary scope should be fixed and disposed
             await this.fixupTemporaryScope();
           }
-          await this.addSymbol(
-            currentLabel,
-            asmLine,
-            new ExpressionValue(this.getCurrentAddress())
-          );
+          if (!isFieldAssignment) {
+            await this.addSymbol(
+              currentLabel,
+              asmLine,
+              new ExpressionValue(this.getCurrentAddress())
+            );
+          }
         }
       }
 


### PR DESCRIPTION
Long story short:
- there was an oversight which I have admitted during #527;
- your fix that came with #529 fixed the label definitions, but it brought the original 527's bug back again;
- here we are with an attempt to make both cases covered gracefully

The root of the problem was lying in the field assignment pragmas that were introducing scope labels which led to label names clashing ending up with error Z0501 eventually.

This pull request includes a fix and a regression test that logically connects the both aforementioned cases and it should prevent breaking changes over this area hopefully.