### PR TITLE
Fix the missing output segment during fixup.

### DIFF
--- a/src/main/z80-compiler/assembler.ts
+++ b/src/main/z80-compiler/assembler.ts
@@ -445,6 +445,7 @@ export class Z80Assembler extends ExpressionEvaluator {
       return false;
     }
     this._output.segments.length = 0;
+    this._currentSegment = null;
     this.ensureCodeSegment();
 
     const currentLineIndex = { index: 0 };

--- a/test/assembler/regression.test.ts
+++ b/test/assembler/regression.test.ts
@@ -126,4 +126,21 @@ describe("Assembler - regression cases", async () => {
     const output = await compiler.compile(source);
     expect(output.errorCount).toBe(0);
   });
+
+  it("fixup - no missing output segments", async () => {
+    const compiler = new Z80Assembler();
+    const source = `
+    .db Bar & 0xFF
+
+    #if ($ >> 8) > ($ & 0xFF)
+    nop
+    #endif
+
+    Bar:
+    jp 0
+    `;
+
+    const output = await compiler.compile(source);
+    expect(output.errorCount).toBe(0);
+  });
 });


### PR DESCRIPTION
This happened when 'current address' specifier is featured in a directive expression;

I have bumped into it when was doing something similar to:
```
.db Bar & 0xFF

#if ($ >> 8) > ($ & 0xFF)
nop
#endif

Bar:
jp 0
```

What was happening is that `executeParse` method had created the current segment indirectly (through the `ensureSegment`), whereas  `emitCode` method was cleraring the output.segments list without nullifying the current segment's field. This way, due to how the `ensureSegment` method's designed the current code segment wasn't pushed to output segments ever since.  And finally some of the fixups (those which were created globally, or better module-wise) end up with a negative code segment index, leading us to the “Cannot read property of undefined” error to happen within the `fixupuSymbols` method:

```
const segment = this._output.segments[fixup.segmentIndex]; // fixup.segmentIndex === -1 here
const emittedCode = segment.emittedCode;                   // 'Cannot read property of undefined' error on this line
```
