### PR TITLE
fix: document navigation on Windows.

### DIFF
--- a/src/renderer/appIde/DocumentPanels/MonacoEditor.tsx
+++ b/src/renderer/appIde/DocumentPanels/MonacoEditor.tsx
@@ -346,7 +346,7 @@ export const MonacoEditor = ({
           options={{
             fontSize: editorFontSize,
             readOnly: document.isReadOnly,
-            glyphMargin: languageInfo.supportsBreakpoints
+            glyphMargin: languageInfo?.supportsBreakpoints
           }}
           loading=''
           width={width}

--- a/src/renderer/appIde/commands/DocumentCommands.ts
+++ b/src/renderer/appIde/commands/DocumentCommands.ts
@@ -1,3 +1,4 @@
+import * as path from "path"
 import { IdeCommandContext } from "../../abstractions/IdeCommandContext";
 import { IdeCommandResult } from "../../abstractions/IdeCommandResult";
 import {
@@ -63,7 +64,7 @@ export class NavigateToDocumentCommand extends IdeCommandBase {
 
     // --- Get the project node
     const projNode = context.service.projectService.getNodeForFile(
-      this.filename
+      path.normalize(this.filename)
     );
     if (!projNode) {
       return commandError(`File '${this.filename}' not found in the project.`);


### PR DESCRIPTION
Path normalization added in order to have uniform path separators when looking for project node.

Without this, for instance clicking a link in the compilation error message won't bring up a document with that particular error on Windows.