### PR TITLE
Filter out any files unrelated with Klive from project file tree.

### DIFF
--- a/src/common/messaging/any-to-main.ts
+++ b/src/common/messaging/any-to-main.ts
@@ -59,6 +59,13 @@ export interface MainCreateKliveProjectRequest extends MessageBase {
 }
 
 /**
+ * The client wants to get a list of globally excluded project items (those, specified inside *.settings file)
+ */
+export interface MainGloballyExcludedProjectItemsRequest extends MessageBase {
+  type: "MainGloballyExcludedProjectItems";
+}
+
+/**
  * The client wants to delete a file entry
  */
 export interface MainDeleteFileEntryRequest extends MessageBase {

--- a/src/common/messaging/dialog-ids.ts
+++ b/src/common/messaging/dialog-ids.ts
@@ -1,2 +1,3 @@
 export const NEW_PROJECT_DIALOG = 1;
 export const EXPORT_CODE_DIALOG = 2;
+export const EXCLUDED_PROJECT_ITEMS_DIALOG = 3;

--- a/src/common/messaging/messages-core.ts
+++ b/src/common/messaging/messages-core.ts
@@ -28,6 +28,7 @@ import {
   MainCreateKliveProjectResponse,
   MainOpenFolderRequest,
   MainAddNewFileEntryRequest,
+  MainGloballyExcludedProjectItemsRequest,
   MainDeleteFileEntryRequest,
   MainRenameFileEntryRequest,
   MainShowOpenFolderDialogRequest,
@@ -165,6 +166,7 @@ export type RequestMessage =
   | MainOpenFolderRequest
   | MainCreateKliveProjectRequest
   | MainAddNewFileEntryRequest
+  | MainGloballyExcludedProjectItemsRequest
   | MainDeleteFileEntryRequest
   | MainRenameFileEntryRequest
   | MainShowOpenFolderDialogRequest

--- a/src/common/state/Action.ts
+++ b/src/common/state/Action.ts
@@ -38,6 +38,7 @@ export type Payload = {
   state: MachineControllerState;
   numValue: number;
   file: string;
+  files: string[];
   text: string;
   compileResult: KliveCompilerOutput;
   failed: string

--- a/src/common/state/ActionTypes.ts
+++ b/src/common/state/ActionTypes.ts
@@ -67,6 +67,8 @@ export interface ActionTypes {
   CLOSE_FOLDER: null;
   SET_BUILD_ROOT: null;
   INC_PROJECT_VERSION: null;
+  ADD_EXCLUDED_PROJECT_ITEM: null;
+  SET_EXCLUDED_PROJECT_ITEMS: null;
 
   DISPLAY_DIALOG: null;
 

--- a/src/common/state/AppState.ts
+++ b/src/common/state/AppState.ts
@@ -90,6 +90,7 @@ export type IdeProject = {
   isKliveProject?: boolean;
   buildRoots?: string[];
   projectVersion: number;
+  excludedItems?: string[];
 }
 
 /**

--- a/src/common/state/actions.ts
+++ b/src/common/state/actions.ts
@@ -312,6 +312,17 @@ export const incProjectVersionAction: ActionCreator = () => ({
   type: "INC_PROJECT_VERSION"
 });
 
+export const addExcludedProjectItemAction: ActionCreator = (file: string) => ({
+  type: "ADD_EXCLUDED_PROJECT_ITEM",
+  payload: { file }
+});
+
+
+export const setExcludedProjectItemsAction: ActionCreator = (files: string[]) => ({
+  type: "SET_EXCLUDED_PROJECT_ITEMS",
+  payload: { files }
+});
+
 export const resetCompileAction: ActionCreator = () => ({
   type: "RESET_COMPILE"
 });

--- a/src/common/state/project-reducer.ts
+++ b/src/common/state/project-reducer.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+
 import { Action } from "./Action";
 import { IdeProject } from "./AppState";
 
@@ -18,9 +20,7 @@ export function projectReducer (
 
     case "CLOSE_FOLDER":
       return {
-        ...state,
-        folderPath: undefined,
-        isKliveProject: false
+        projectVersion: 0
       };
 
     case "SET_BUILD_ROOT":
@@ -34,6 +34,26 @@ export function projectReducer (
         ...state,
         projectVersion: state.projectVersion + 1
       };
+
+    case "ADD_EXCLUDED_PROJECT_ITEM": {
+      const excludedItems = [
+          path.relative(state.folderPath, payload.file.trim())
+            .replace(path.sep, "/")
+        ];
+      return {
+        ...state,
+        excludedItems: state.excludedItems
+          ? state.excludedItems.concat(excludedItems)
+              .filter((v,i,a) => a.indexOf(v) === i)
+          : excludedItems
+      }
+    }
+
+    case "SET_EXCLUDED_PROJECT_ITEMS":
+      return {
+        ...state,
+        excludedItems: payload.files
+      }
 
     default:
       return state;

--- a/src/main/app-menu.ts
+++ b/src/main/app-menu.ts
@@ -45,7 +45,8 @@ import { appSettings, saveAppSettings } from "./settings";
 import { openFolder, saveKliveProject } from "./projects";
 import {
   EXPORT_CODE_DIALOG,
-  NEW_PROJECT_DIALOG
+  NEW_PROJECT_DIALOG,
+  EXCLUDED_PROJECT_ITEMS_DIALOG,
 } from "../common/messaging/dialog-ids";
 import { TapeDataBlock } from "../common/structs/TapeDataBlock";
 import { IdeExecuteCommandResponse } from "@common/messaging/any-to-ide";
@@ -73,6 +74,7 @@ const INJECT_CODE = "inject_code";
 const RUN_CODE = "run_code";
 const DEBUG_CODE = "debug_code";
 const EXPORT_CODE = "export_code";
+const EXCLUDED_PROJECT_ITEMS = "manage_excluded_items";
 
 const SHOW_IDE_WINDOW = "show_ide_window";
 
@@ -597,7 +599,16 @@ export function setupMenu (
           click: () => {
             mainStore.dispatch(displayDialogAction(EXPORT_CODE_DIALOG));
           }
-        }
+        },
+        { type: "separator" },
+        {
+          id: EXCLUDED_PROJECT_ITEMS,
+          label: "Manage Excluded Items",
+          enabled: true,
+          click: () => {
+            mainStore.dispatch(displayDialogAction(EXCLUDED_PROJECT_ITEMS_DIALOG));
+          }
+        },
       ]
     });
   }
@@ -876,11 +887,11 @@ async function showMessage (
 }
 
 const registeredMachines = [
-  { 
+  {
     id: "sp48",
     displayName: "ZX Spectrum 48K"
   },
-  { 
+  {
     id: "sp128",
     displayName: "ZX Spectrum 128K"
   },

--- a/src/main/directory-content.ts
+++ b/src/main/directory-content.ts
@@ -1,0 +1,93 @@
+import * as path from "path";
+import * as fs from "fs";
+
+import { app } from "electron";
+import { ProjectNodeWithChildren } from "../renderer/appIde/project/project-node";
+import {
+  getKliveProjectStructure,
+} from "./projects";
+import {
+  appSettings,
+  saveAppSettings
+} from "./settings";
+
+type DirectoryContentFilter = (p: string) => boolean;
+
+/**
+ * Gets the contents of the specified directory
+ * @param root
+ */
+export async function getDirectoryContent (
+  root: string,
+  pred?: DirectoryContentFilter
+): Promise<ProjectNodeWithChildren> {
+  if (!path.isAbsolute(root)) {
+    root = path.join(app.getPath("home"), root);
+  }
+
+  let fileEntryCount = 0;
+  const folderSegments = root.split(path.sep);
+  const lastFolder =
+    folderSegments.length > 0
+      ? folderSegments[folderSegments.length - 1]
+      : root;
+  return getFileEntryInfo(root, "", lastFolder);
+
+  function getFileEntryInfo (
+    entryPath: string,
+    projectRelative: string,
+    name: string
+  ): ProjectNodeWithChildren {
+    // --- Store the root node information
+    const fileEntryInfo = fs.statSync(entryPath);
+    const entry: ProjectNodeWithChildren = {
+      isFolder: false,
+      name,
+      fullPath: entryPath,
+      projectPath: projectRelative,
+      children: []
+    };
+    if (fileEntryInfo.isFile()) {
+      fileEntryCount++;
+      return entry;
+    }
+    if (fileEntryInfo.isDirectory()) {
+      entry.isFolder = true;
+      const names = fs.readdirSync(entryPath);
+      for (const name of names) {
+        if (fileEntryCount++ > 10240) break;
+        const projectRelativeChild = path.join(projectRelative, name);
+        if (pred(projectRelativeChild)) {
+          entry.children.push(
+            getFileEntryInfo(
+              path.join(entryPath, name),
+              projectRelativeChild,
+              name
+            )
+          );
+        }
+      }
+      return entry;
+    }
+  }
+}
+
+/**
+ * Retrieves a directory content filter for a project file tree.
+ * This filter sieves off the excluded project items.
+ * @returns a DirectoryContentFilter promise
+ */
+export async function getProjectDirectoryContentFilter(
+): Promise<DirectoryContentFilter> {
+  const projPromise = getKliveProjectStructure();
+  if (!appSettings.excludedProjectItems) {
+    appSettings.excludedProjectItems = [ ".git" ];
+    saveAppSettings();
+  }
+  const proj = await projPromise;
+  const ignored = appSettings.excludedProjectItems
+    .concat(proj.ide.excludedProjectItems)
+    .filter((value, index, array) => array.indexOf(value) === index)
+    .map((v) => v.replace('/', path.sep));
+  return (p: string) => !ignored.some(v => p.startsWith(v));
+}

--- a/src/main/projects.ts
+++ b/src/main/projects.ts
@@ -7,6 +7,7 @@ import {
   primaryBarOnRightAction,
   resetCompileAction,
   setBuildRootAction,
+  setExcludedProjectItemsAction,
   setIdeFontSizeAction,
   showEmuStatusBarAction,
   showEmuToolbarAction,
@@ -122,6 +123,9 @@ export function openFolderByPath (projectFolder: string): string | null {
   if (!fs.existsSync(projectFolder)) {
     return `Folder ${projectFolder} does not exists.`;
   }
+  const disp = mainStore.dispatch;
+  disp(closeFolderAction());
+
   const projectFile = path.join(projectFolder, PROJECT_FILE);
   let isValidProject = false;
   if (fs.existsSync(projectFile)) {
@@ -131,7 +135,7 @@ export function openFolderByPath (projectFolder: string): string | null {
       isValidProject = !!(projectStruct.kliveVersion && projectStruct.machineType);
 
       // --- Apply settings if the project is valid
-      const disp = mainStore.dispatch;
+      disp(setExcludedProjectItemsAction(projectStruct.ide?.excludedProjectItems));
       disp(showEmuToolbarAction(projectStruct.viewOptions.showEmuToolbar));
       disp(showEmuStatusBarAction(projectStruct.viewOptions.showEmuStatusbar));
       disp(showIdeToolbarAction(projectStruct.viewOptions.showIdeToolbar));
@@ -149,9 +153,8 @@ export function openFolderByPath (projectFolder: string): string | null {
       // --- Intentionally ingored
     }
   }
-    
-  mainStore.dispatch(closeFolderAction());
-  mainStore.dispatch(openFolderAction(projectFolder, isValidProject));
+
+  disp(openFolderAction(projectFolder, isValidProject));
 
   // --- Save the folder into settings
   appSettings.folders ??= {};
@@ -267,7 +270,9 @@ export async function getKliveProjectStructure(): Promise<KliveProjectStructure>
     tapeFile: state.emulatorState.tapeFile,
     fastLoad: state.emulatorState.fastLoad,
     machineSpecific: {},
-    ide: {},
+    ide: {
+      excludedProjectItems: state.project?.excludedItems ?? []
+    },
     viewOptions: {
       theme: state.theme,
       editorFontSize: state.ideViewOptions?.editorFontSize,

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -12,7 +12,8 @@ export type AppSettings = {
     ideWindow?: WindowState,
     showIdeOnStartup?: boolean;
   },
-  folders?: Record<string, string>
+  folders?: Record<string, string>,
+  excludedProjectItems?: string[]
 };
 
 export let appSettings: AppSettings = {};

--- a/src/renderer/appIde/IdeApp.tsx
+++ b/src/renderer/appIde/IdeApp.tsx
@@ -9,7 +9,11 @@ import {
 } from "@renderer/core/RendererProvider";
 import { activityRegistry, toolPanelRegistry } from "@renderer/registry";
 import { ToolInfo } from "@renderer/abstractions/ToolInfo";
-import { EXPORT_CODE_DIALOG, NEW_PROJECT_DIALOG } from "@messaging/dialog-ids";
+import {
+  EXPORT_CODE_DIALOG,
+  NEW_PROJECT_DIALOG,
+  EXCLUDED_PROJECT_ITEMS_DIALOG
+} from "@messaging/dialog-ids";
 import {
   RequestMessage,
   NotReadyResponse,
@@ -70,6 +74,7 @@ import { NavigateToDocumentCommand } from "./commands/DocumentCommands";
 import { SelectOutputPaneCommand } from "./commands/ToolCommands";
 import { ExportCodeDialog } from "./dialogs/ExportCodeDialog";
 import { IdeEventsHandler } from "./IdeEventsHandler";
+import { ExcludedProjectItemsDialog } from "./dialogs/ExcludedProjectItemsDialog";
 
 // --- Store the singleton instances we use for message processing (out of React)
 let appServicesCached: AppServices;
@@ -186,6 +191,13 @@ const IdeApp = () => {
       {dialogId === EXPORT_CODE_DIALOG && (
         <ExportCodeDialog
           onExport={async () => {}}
+          onClose={() => {
+            store.dispatch(displayDialogAction());
+          }}
+        />
+      )}
+      {dialogId === EXCLUDED_PROJECT_ITEMS_DIALOG && (
+        <ExcludedProjectItemsDialog
           onClose={() => {
             store.dispatch(displayDialogAction());
           }}

--- a/src/renderer/appIde/SiteBarPanels/ExplorerPanel.tsx
+++ b/src/renderer/appIde/SiteBarPanels/ExplorerPanel.tsx
@@ -31,6 +31,7 @@ import { RenameDialog } from "../dialogs/RenameDialog";
 import { DeleteDialog } from "../dialogs/DeleteDialog";
 import { NewItemDialog } from "../dialogs/NewItemDialog";
 import {
+  addExcludedProjectItemAction,
   displayDialogAction,
   incDocumentActivationVersionAction,
   setBuildRootAction
@@ -49,7 +50,7 @@ let lastExplorerPath = "";
 
 const ExplorerPanel = () => {
   // --- Services used in this component
-  const { messenger } = useRendererContext();
+  const { messenger, store } = useRendererContext();
   const dispatch = useDispatch();
   const { projectService, documentService, ideCommandsService } =
     useAppServices();
@@ -70,7 +71,10 @@ const ExplorerPanel = () => {
   const [isFocused, setIsFocused] = useState(false);
 
   // --- Information about a project (Is any project open? Is it a Klive project?)
-  const folderPath = useSelector(s => s.project?.folderPath);
+  const {folderPath, excludedItems} = useSelector(s => ({
+    folderPath: s.project?.folderPath,
+    excludedItems: s.project?.excludedItems,
+  }));
   const isKliveProject = useSelector(s => s.project?.isKliveProject);
   const buildRoots = useSelector(s => s.project?.buildRoots ?? EMPTY_ARRAY);
 
@@ -112,7 +116,7 @@ const ExplorerPanel = () => {
     await new Promise(r => setTimeout(r, 100));
     const response = await messenger.sendMessage({ type: "MainSaveProject" });
     if (response.type === "ErrorResponse") {
-      reportMessagingError(`EmuGetMemory request failed: ${response.message}`);
+      reportMessagingError(`MainSaveProject request failed: ${response.message}`);
     }
   };
 
@@ -167,6 +171,35 @@ const ExplorerPanel = () => {
         clicked={() => setIsRenameDialogOpen(true)}
       />
       <ContextMenuItem
+        text='Exclude'
+        disabled={selectedNodeIsProjectFile || selectedNodeIsRoot}
+        clicked={async () => {
+          if (selectedNodeIsBuildRoot) {
+            // Excluded items are revoked from build root automatically.
+            dispatch(setBuildRootAction(
+                selectedContextNode.data.projectPath,
+                false
+              ));
+          }
+
+          dispatch(addExcludedProjectItemAction(
+              selectedContextNode.data.fullPath
+            ));
+
+          const savePromise = saveProject();
+          // Meanwhile find and close any of the excluded documents.
+          if (selectedContextNode.data.isFolder) {
+            store.getState().ideView?.openDocuments
+              .filter(doc => doc.id.startsWith(selectedContextNode.data.fullPath))
+              .forEach(doc => documentService.closeDocument(doc.id));
+          } else {
+            documentService.closeDocument(selectedContextNode.data.fullPath);
+          }
+          await savePromise;
+        }}
+      />
+      <ContextMenuItem
+        dangerous={true}
         text='Delete'
         disabled={selectedNodeIsProjectFile || selectedNodeIsRoot}
         clicked={() => setIsDeleteDialogOpen(true)}
@@ -177,7 +210,7 @@ const ExplorerPanel = () => {
           <ContextMenuItem
             text={
               selectedNodeIsBuildRoot
-                ? "Remove from Build Root"
+                ? "Demote from Build Root"
                 : "Promote to Build Root"
             }
             clicked={async () => {
@@ -465,6 +498,10 @@ const ExplorerPanel = () => {
     };
   }, [projectService]);
 
+  useEffect(() => {
+    if (lastExplorerPath) folderCache.delete(lastExplorerPath);
+  }, [excludedItems])
+
   // --- Get the current project tree when the project path changes
   useEffect(() => {
     (async () => {
@@ -512,7 +549,7 @@ const ExplorerPanel = () => {
         folderCache.set(folderPath, projectTree);
       }
     })();
-  }, [folderPath]);
+  }, [folderPath, excludedItems]);
 
   // --- Render the Explorer panel
   return folderPath ? (

--- a/src/renderer/appIde/dialogs/ExcludedProjectItemsDialog.module.scss
+++ b/src/renderer/appIde/dialogs/ExcludedProjectItemsDialog.module.scss
@@ -1,0 +1,48 @@
+@import "@styles/core.scss";
+
+.listWrapper {
+  @include fill-parent-flex;
+  box-sizing: border-box;
+  flex-direction: column;
+  user-select: none;
+  height: 120pt;
+  background-color: var(--bgcolor-modal);
+  margin-top: 8pt;
+}
+
+.listItem {
+  height:30pt;
+  width: auto;
+  display: flex;
+  padding-left: 8pt;
+  padding-right: 16pt;
+
+  * {
+    margin-bottom: auto;
+    margin-top: auto;
+  }
+}
+
+.listItemTitle {
+  width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.removeButton {
+  display: flex;
+  height: auto;
+  align-items: center;
+
+  &:hover {
+    border-radius: 4px;
+    background: var(--bgcolor-tabbutton-pointed);
+  }
+}
+
+.disabled,
+.disabled:hover {
+  background: transparent;
+  opacity: .5;
+}

--- a/src/renderer/appIde/dialogs/ExcludedProjectItemsDialog.tsx
+++ b/src/renderer/appIde/dialogs/ExcludedProjectItemsDialog.tsx
@@ -1,0 +1,153 @@
+import * as path from "path";
+import * as fs from "fs";
+
+import styles from "./ExcludedProjectItemsDialog.module.scss";
+import { ModalApi, Modal } from "@controls/Modal";
+import { useEffect, useRef, useState } from "react";
+import classnames from "@renderer/utils/classnames";
+import { useDispatch, useRendererContext, useSelector } from "@renderer/core/RendererProvider";
+import { DialogRow } from "@renderer/controls/DialogRow";
+import { Label } from "@renderer/controls/Labels";
+import { VirtualizedListView } from "@controls/VirtualizedListView";
+import { TabButton } from "@renderer/controls/TabButton";
+import { TooltipFactory } from "@renderer/controls/Tooltip";
+import { setExcludedProjectItemsAction } from "@common/state/actions";
+import { reportMessagingError } from "@renderer/reportError";
+
+type Props = {
+  onClose: () => void;
+};
+
+export const ExcludedProjectItemsDialog = ({ onClose }: Props) => {
+  const { messenger, store } = useRendererContext();
+
+  // --- Saves the current project
+  const saveProject = async () => {
+    await new Promise(r => setTimeout(r, 100));
+    const response = await messenger.sendMessage({ type: "MainSaveProject" });
+    if (response.type === "ErrorResponse") {
+      reportMessagingError(`MainSaveProject request failed: ${response.message}`);
+    }
+  };
+
+  const [ globalExcludes, setGlobalExcludes ] = useState([]);
+  useEffect(() => {
+    messenger.sendMessage({
+      type: "MainGloballyExcludedProjectItems"
+    }).then(response => {
+      if (response.type == "TextContents") {
+        setGlobalExcludes(response.contents.split(path.delimiter));
+      }
+    });
+  },[ /* once */ ]);
+
+  const project = store.getState().project;
+  const [excludedItems, setExcludedItems] = useState(project?.excludedItems);
+  const projectName = useSelector(s => path.basename(s.project?.folderPath ?? "Unnamed"));
+
+  const disp = useDispatch();
+
+  return (
+    <Modal
+      title='Excluded Items'
+      isOpen={true}
+      fullScreen={false}
+      width={500}
+      primaryLabel='OK'
+      primaryEnabled={true}
+      initialFocus='none'
+      onPrimaryClicked={async () => {
+        disp(setExcludedProjectItemsAction(excludedItems));
+        await saveProject();
+        return false;
+      }}
+      onClose={() => {
+        onClose();
+      }}
+    >
+      <DialogRow label={`${projectName} Excludes:`}>
+        <div className={styles.listWrapper}>
+          <VirtualizedListView
+            items={excludedItems}
+            approxSize={30}
+            fixItemHeight={false}
+            itemRenderer={idx => (<>
+              <ExcludedItem
+                root={project?.folderPath}
+                value={excludedItems[idx]}
+                onRemove={_ => setExcludedItems(
+                  excludedItems.filter((_, i) => i !== idx))}/>
+            </>)}
+          />
+        </div>
+      </DialogRow>
+      <DialogRow label='Global Excludes:'>
+        <div className={styles.listWrapper}>
+          <VirtualizedListView
+            items={globalExcludes}
+            approxSize={30}
+            fixItemHeight={false}
+            itemRenderer={idx => (<>
+              <ExcludedItem
+                root={project?.folderPath}
+                value={globalExcludes[idx]}/>
+            </>)}
+          />
+        </div>
+      </DialogRow>
+    </Modal>
+  );
+};
+
+type ItemProps = {
+  root: string,
+  value: string,
+  onRemove?: (value:string) => void,
+};
+
+const ExcludedItem = ({root, value, onRemove = undefined}: ItemProps) => {
+  const ref = useRef(null);
+  const [mouseOver, setMouseOver] = useState(false);
+  const [offset, setOffset] = useState({x:0, y:0});
+
+  const disabled = !onRemove;
+  const missing = !fs.existsSync(path.join(root, value.replace('/', path.sep)));
+
+  return (
+    <div
+      className={classnames(styles.listItem, {
+        [styles.disabled]: disabled
+      })}
+      onMouseEnter={() => setMouseOver(true)}
+      onMouseLeave={() => setMouseOver(false)}>
+        { missing && <Label text="!" width={12} /> }
+        <div className={styles.listItemTitle}>
+          <span
+            ref={ref}
+            onMouseOver={e => {
+              const rc = (e.target as HTMLElement)?.getBoundingClientRect();
+              setOffset({
+                x: (rc ? e.clientX - .5 * (rc.left + rc.right) : 0),
+                ...offset, // y: (rc ? e.clientY - rc.bottom : 0)
+              });
+            }}>
+              {value}
+          </span>
+        </div>
+        <TabButton
+          iconName="close"
+          disabled={disabled}
+          hide={disabled || !mouseOver}
+          clicked={() => onRemove(value)}/>
+
+        <TooltipFactory refElement={ref.current}
+          placement='top'
+          offsetX={offset.x}
+          offsetY={offset.y}
+          isShown={mouseOver}>
+            {value}
+        </TooltipFactory>
+
+    </div>
+  );
+};

--- a/src/renderer/controls/ContextMenu.module.scss
+++ b/src/renderer/controls/ContextMenu.module.scss
@@ -10,6 +10,10 @@
     padding: 2px 12px;
     cursor: pointer;
 
+    &.dangerous {
+      color: var(--color-context-item-dangerous);
+    }
+
     &.disabled {
       background-color: var(--bgcolor-context-item-disabled);
       color: var(--color-context-item-disabled);

--- a/src/renderer/controls/ContextMenu.tsx
+++ b/src/renderer/controls/ContextMenu.tsx
@@ -62,15 +62,17 @@ export const ContextMenu = ({
 };
 
 type ContextMenuItemProps = {
+  dangerous?: boolean;
   text?: string;
   disabled?: boolean;
   clicked?: () => void;
 };
 
-export const ContextMenuItem = ({ text, disabled, clicked }: ContextMenuItemProps) => {
+export const ContextMenuItem = ({ dangerous, text, disabled, clicked }: ContextMenuItemProps) => {
   return (
     <div
       className={classnames(localStyles.menuItem, {
+        [localStyles.dangerous]: dangerous,
         [localStyles.disabled]: disabled
       })}
       onMouseDown={e => {

--- a/src/renderer/controls/Tooltip.tsx
+++ b/src/renderer/controls/Tooltip.tsx
@@ -73,7 +73,7 @@ export const Tooltip = ({
         {
           name: "offset",
           options: {
-            offset: [offsetY, offsetX]
+            offset: [offsetX, offsetY]
           }
         }
       ],

--- a/src/renderer/registry.ts
+++ b/src/renderer/registry.ts
@@ -230,6 +230,13 @@ export const fileTypeRegistry: FileTypeEditor[] = [
   },
   {
     matchType: "ends",
+    pattern: ".txt",
+    editor: CODE_EDITOR,
+    subType: "plain-text",
+    icon: "@file-text-txt"
+  },
+  {
+    matchType: "ends",
     pattern: ".tzx",
     editor: TAP_EDITOR,
     icon: "@file-tap-tzx",

--- a/src/renderer/theming/dark-theme.ts
+++ b/src/renderer/theming/dark-theme.ts
@@ -43,6 +43,7 @@ export const darkTheme: ThemeProperties = {
   // --- Context menu
   "--bgcolor-context-menu": "#282828",
   "--color-context-item": "#cccccc",
+  "--color-context-item-dangerous": "#c50f1f",
   "--color-context-item-disabled": "#606060",
   "--bgcolor-context-item-pointed": "#007acc",
   "--color-context-item-pointed": "#ffffff",

--- a/src/renderer/theming/light-theme.ts
+++ b/src/renderer/theming/light-theme.ts
@@ -43,6 +43,7 @@ export const lightTheme: ThemeProperties = {
   // --- Context menu
   "--bgcolor-context-menu": "#d8d8d8",
   "--color-context-item": "#414141",
+  "--color-context-item-dangerous": "#c50f1f",
   "--color-context-item-disabled": "#a0a0a0",
   "--bgcolor-context-item-pointed": "#007acc",
   "--color-context-item-pointed": "#ffffff",

--- a/src/renderer/theming/theme.ts
+++ b/src/renderer/theming/theme.ts
@@ -43,6 +43,7 @@ export type ThemeProperties = {
   // --- Context menu
   "--bgcolor-context-menu"?: string;
   "--color-context-item"?: string;
+  "--color-context-item-dangerous"?: string;
   "--color-context-item-disabled"?: string;
   "--bgcolor-context-item-pointed"?: string;
   "--color-context-item-pointed"?: string;


### PR DESCRIPTION
Here we have file tree filtering, so anything unrelated with Klive is shown under the project tree. Given how the project tree is being build I think this is the simplest solution that gets job done.

User is now enabled to exclude any unwanted items from their project:
![electron_JgDwsqBM0i](https://github.com/Dotneteer/kliveide/assets/5775412/eedcb172-910c-41ee-81ce-12db42b92705)
