### PR TITLE
Fix the App's main menu weird behaviour.

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,7 +32,7 @@ import {
   unloadWindowsAction
 } from "../common/state/actions";
 import { Unsubscribe } from "../common/state/redux-light";
-import { app, BrowserWindow, shell, ipcMain } from "electron";
+import { app, BrowserWindow, shell, ipcMain, Menu } from "electron";
 import { release } from "os";
 import { join } from "path";
 import { setupMenu } from "./app-menu";
@@ -194,6 +194,8 @@ async function createAppWindows () {
   registerMainToEmuMessenger(emuWindow);
   registerMainToIdeMessenger(ideWindow);
 
+  // Rather than setting up the application menu we'll configure it per window.
+  Menu.setApplicationMenu(null);
   // --- Prepare the main menu. Update items on application state change
   setupMenu(emuWindow, ideWindow);
 


### PR DESCRIPTION
There were two issues intertwined: first, the menu separators weren't removed after empty sections; and the second, the menu contents dependent of focused windows state could get stale that's because how window focusing works.

![electron_Nr55BXDHb7](https://github.com/Dotneteer/kliveide/assets/5775412/bd129d7d-c41d-473b-ad77-2349ec3d13e7)

@Dotneteer , please check whether it works for you on macOS.

The test cases are like that:

The First
1. Launch Klive
2. Make sure **_IDE window_** is open
3. Focus it
4. Now click 'View' menu item on **_EMU window_**
**What to expect**: the menu won't bring up before the EMU window gets focused. Click the 'View' item on EMU window again to see the menu filled up correctly with its corresponding context.

The Second
1. Launch Klive
2. Make sure both windows are open
3. Unfocus all the windows
4. Now click the 'View' menu item on any of the windows
**What to expect**: the menu won't bring up before the chosen window gets focused. Click 'VIew' item on that window again to see the menu with it's corresponding context.
