### PR TITLE
Fix: #include inside the scope of non-met #if condition.

### DIFF
--- a/src/main/z80-compiler/assembler.ts
+++ b/src/main/z80-compiler/assembler.ts
@@ -27,6 +27,7 @@ import {
   DefGPragma,
   DefGxPragma,
   DefHPragma,
+  DefineDirective,
   DefMPragma,
   DefNPragma,
   DefSPragma,
@@ -86,6 +87,7 @@ import {
   SubInstruction,
   TestInstruction,
   TracePragma,
+  UndefDirective,
   UntilStatement,
   VarPragma,
   WhileStatement,
@@ -378,47 +380,64 @@ export class Z80Assembler extends ExpressionEvaluator {
     while (currentLineIndex < visitedLines.length) {
       const line = visitedLines[currentLineIndex];
       this.setSourceLine(line);
-      switch (line.type) {
-        case "ModelPragma":
-          this.processModelPragma(line as unknown as ModelPragma);
-          break;
-        case "IncludeDirective": {
-          // --- Parse the included file
-          const includedLines = await this.applyIncludeDirective(
-            line as unknown as IncludeDirective,
-            sourceItem
-          );
-          if (includedLines.success && includedLines.parsedLines) {
-            // --- Add the parse result of the include file to the result
-            parsedLines.push(...includedLines.parsedLines);
-          }
+      if (processOps.ops) {
+        const typedLine = line as any;
+        switch (typedLine.type) {
+          case "ModelPragma":
+            this.processModelPragma(typedLine);
+            break;
 
-          break;
-        }
-        case "LineDirective":
-          // TODO: Process a #line directive
-          break;
-        default: {
-          if (
-            this.applyDirective(
-              line as unknown as Directive,
-              ifdefStack,
-              processOps
-            )
-          ) {
+          case "IncludeDirective": {
+            // --- Parse the included file
+            const includedLines = await this.applyIncludeDirective(
+              typedLine,
+              sourceItem
+            );
+            if (includedLines.success && includedLines.parsedLines) {
+              // --- Add the parse result of the include file to the result
+              parsedLines.push(...includedLines.parsedLines);
+            }
             break;
           }
-          if (processOps.ops) {
-            line.fileIndex = fileIndex;
-            line.sourceText = sourceText.substr(
-              line.startPosition,
-              line.endPosition - line.startPosition + 1
-            );
-            parsedLines.push(line);
-          }
 
-          break;
+          case "DefineDirective":
+            this.conditionSymbols[typedLine.identifier.name] =
+              new ExpressionValue(true);
+            break;
+
+          case "UndefDirective":
+            delete this.conditionSymbols[typedLine.identifier.name];
+            break;
+
+          case "LineDirective":
+            // TODO: Process a #line directive
+            break;
+
+          default: {
+            if (
+              !this.applyScopedDirective(
+                line as unknown as Directive,
+                ifdefStack,
+                processOps
+              )
+            ) {
+              line.fileIndex = fileIndex;
+              line.sourceText = sourceText.substr(
+                line.startPosition,
+                line.endPosition - line.startPosition + 1
+              );
+              parsedLines.push(line);
+            }
+            break;
+          }
         }
+      }
+      else {
+        this.applyScopedDirective(
+          line as unknown as Directive,
+          ifdefStack,
+          processOps
+        );
       }
       currentLineIndex++;
     }
@@ -712,38 +731,24 @@ export class Z80Assembler extends ExpressionEvaluator {
   }
 
   /**
-   * Apply the specified directive
+   * Apply the specified scoped directive
    * @param directive Directive to apply
    * @param ifdefStack Stack if conditional directives
    * @param processOps Object with the "process operation" flag
    * @returns True, if the directive has been processed successfully
    */
-  applyDirective (
+  applyScopedDirective (
     directive: Directive,
     ifdefStack: (boolean | null)[],
     processOps: ProcessOps
   ): boolean {
-    const doProc = processOps.ops;
     switch (directive.type) {
-      case "DefineDirective":
-        if (doProc) {
-          this.conditionSymbols[directive.identifier.name] =
-            new ExpressionValue(true);
-        }
-        break;
-
-      case "UndefDirective":
-        if (doProc) {
-          delete this.conditionSymbols[directive.identifier.name];
-        }
-        break;
-
       case "IfDefDirective":
       case "IfNDefDirective":
       case "IfModDirective":
       case "IfNModDirective":
       case "IfDirective":
-        if (doProc) {
+        if (processOps.ops) {
           if (directive.type === "IfDirective") {
             const value = this.evaluateExprImmediate(directive.condition);
             processOps.ops = value.isValid && value.value !== 0;
@@ -5369,8 +5374,8 @@ export class Z80Assembler extends ExpressionEvaluator {
       }
     }
     this.reportAssemblyError(
-      "Z0604", 
-      op, 
+      "Z0604",
+      op,
       toPosition(issueWithOp1 ? op.operand1.startToken : op.operand2.startToken));
   }
 

--- a/test/assembler/directive.test.ts
+++ b/test/assembler/directive.test.ts
@@ -311,7 +311,7 @@ describe("Assembler - directives", async () => {
       #endif
       nop ; 6
       nop ; 7
-      nop ; 8 
+      nop ; 8
       nop ; 9
       #endif
     `;
@@ -337,7 +337,7 @@ describe("Assembler - directives", async () => {
       #endif
       nop ; 3
       nop ; 4
-      nop ; 5 
+      nop ; 5
       nop ; 6
       #endif
     `;
@@ -354,8 +354,8 @@ describe("Assembler - directives", async () => {
     options.predefinedSymbols["MySymbol2"] = new ExpressionValue(true);
     const source = `
       #ifdef MySymbol
-      nop 
-      nop 
+      nop
+      nop
       #ifdef MySymbol2
       nop
       nop
@@ -363,7 +363,7 @@ describe("Assembler - directives", async () => {
       #endif
       nop
       nop
-      nop 
+      nop
       nop
       #endif
     `;
@@ -379,8 +379,8 @@ describe("Assembler - directives", async () => {
     const options = new AssemblerOptions();
     const source = `
       #ifdef MySymbol
-      nop 
-      nop 
+      nop
+      nop
       #ifdef MySymbol2
       nop
       nop
@@ -388,7 +388,7 @@ describe("Assembler - directives", async () => {
       #endif
       nop
       nop
-      nop 
+      nop
       nop
       #endif
     `;
@@ -481,7 +481,7 @@ describe("Assembler - directives", async () => {
       #endif
       nop ; 4
       nop ; 5
-      nop ; 6 
+      nop ; 6
       nop ; 7
       #endif
     `;
@@ -590,19 +590,19 @@ describe("Assembler - directives", async () => {
     options.predefinedSymbols["MySymbol2"] = new ExpressionValue(true);
     const source = `
       #ifdef MySymbol
-      nop 
+      nop
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #else
       nop
       nop
       nop
       #endif
-      nop 
-      nop 
-      nop 
-      nop 
+      nop
+      nop
+      nop
+      nop
       #else
       nop ; 1
       nop ; 2
@@ -624,19 +624,19 @@ describe("Assembler - directives", async () => {
     options.predefinedSymbols["MySymbol2"] = new ExpressionValue(true);
     const source = `
       #ifdef MySymbol
-      nop 
+      nop
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #else
       nop
       nop
       nop
       #endif
-      nop 
-      nop 
-      nop 
-      nop 
+      nop
+      nop
+      nop
+      nop
       #endif
     `;
 
@@ -652,15 +652,15 @@ describe("Assembler - directives", async () => {
     options.predefinedSymbols["MySymbol2"] = new ExpressionValue(true);
     const source = `
       #ifdef MySymbol
-      nop 
+      nop
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #endif
-      nop 
-      nop 
-      nop 
-      nop 
+      nop
+      nop
+      nop
+      nop
       #else
       nop ; 1
       nop ; 2
@@ -681,19 +681,19 @@ describe("Assembler - directives", async () => {
     const options = new AssemblerOptions();
     const source = `
       #ifdef MySymbol
-      nop 
+      nop
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #else
       nop
       nop
       nop
       #endif
-      nop 
-      nop 
-      nop 
-      nop 
+      nop
+      nop
+      nop
+      nop
       #else
       nop ; 1
       nop ; 2
@@ -714,19 +714,19 @@ describe("Assembler - directives", async () => {
     const options = new AssemblerOptions();
     const source = `
       #ifdef MySymbol
-      nop 
+      nop
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #else
       nop
       nop
       nop
       #endif
-      nop 
-      nop 
-      nop 
-      nop 
+      nop
+      nop
+      nop
+      nop
       #endif
     `;
 
@@ -741,15 +741,15 @@ describe("Assembler - directives", async () => {
     const options = new AssemblerOptions();
     const source = `
       #ifdef MySymbol
-      nop 
+      nop
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #endif
-      nop 
-      nop 
-      nop 
-      nop 
+      nop
+      nop
+      nop
+      nop
       #else
       nop ; 1
       nop ; 2
@@ -780,8 +780,8 @@ describe("Assembler - directives", async () => {
       #else
       nop
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #else
       nop
       nop
@@ -812,8 +812,8 @@ describe("Assembler - directives", async () => {
       #else
       nop
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #endif
       nop
       #endif
@@ -840,8 +840,8 @@ describe("Assembler - directives", async () => {
       #else
       nop
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #else
       nop
       nop
@@ -872,8 +872,8 @@ describe("Assembler - directives", async () => {
       #else
       nop
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #endif
       nop
       #endif
@@ -891,11 +891,11 @@ describe("Assembler - directives", async () => {
     options.predefinedSymbols["MySymbol2"] = new ExpressionValue(true);
     const source = `
       #ifdef MySymbol
-      nop 
-      nop 
-      nop 
-      nop 
-      nop 
+      nop
+      nop
+      nop
+      nop
+      nop
       #else
       nop ; 1
       #ifdef MySymbol2
@@ -922,11 +922,11 @@ describe("Assembler - directives", async () => {
     options.predefinedSymbols["MySymbol2"] = new ExpressionValue(true);
     const source = `
       #ifdef MySymbol
-      nop 
-      nop 
-      nop 
-      nop 
-      nop 
+      nop
+      nop
+      nop
+      nop
+      nop
       #else
       nop ; 1
       #ifdef MySymbol2
@@ -948,16 +948,16 @@ describe("Assembler - directives", async () => {
     const options = new AssemblerOptions();
     const source = `
       #ifdef MySymbol
-      nop 
-      nop 
-      nop 
-      nop 
-      nop 
+      nop
+      nop
+      nop
+      nop
+      nop
       #else
       nop ; 1
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #else
       nop ; 2
       nop ; 3
@@ -978,16 +978,16 @@ describe("Assembler - directives", async () => {
     const options = new AssemblerOptions();
     const source = `
       #ifdef MySymbol
-      nop 
-      nop 
-      nop 
-      nop 
-      nop 
+      nop
+      nop
+      nop
+      nop
+      nop
       #else
       nop ; 1
       #ifdef MySymbol2
-      nop 
-      nop 
+      nop
+      nop
       #endif
       nop ; 2
       #endif
@@ -1199,5 +1199,46 @@ describe("Assembler - directives", async () => {
 
     expect(output.errorCount).toBe(1);
     expect(output.errors[0].errorCode === "Z0206").toBe(true);
+  });
+
+  it("#if false holds back an include", async () => {
+    const compiler = new Z80Assembler();
+    const options = new AssemblerOptions();
+    const source = `
+      nop ; 1
+      #if false
+      nop
+      nop
+      #include "/dev/null"
+      nop
+      #endif
+      nop ; 2
+    `;
+
+    const output = await compiler.compile(source, options);
+
+    expect(output.errorCount).toBe(0);
+    expect(compiler.preprocessedLines.length).toBe(2);
+  });
+
+  it("#if true-else holds back an include", async () => {
+    const compiler = new Z80Assembler();
+    const options = new AssemblerOptions();
+    const source = `
+      nop ; 1
+      #if true
+      nop ; 2
+      nop ; 3
+      #else
+      #include "/dev/null"
+      nop
+      #endif
+      nop ; 4
+    `;
+
+    const output = await compiler.compile(source, options);
+
+    expect(output.errorCount).toBe(0);
+    expect(compiler.preprocessedLines.length).toBe(4);
   });
 });


### PR DESCRIPTION
I decided to re-factor my project a little. One of the refactoring steps was to split the code base into smaller files introducing the header guards so to prevent the same code from multiple inclusion. 

This is how I bumped into an issue: includes that found themselves within the supposedly skipped conditional scopes were expanded and parsed. Here's the fix. :)

P.S.: The model pragma is also refrained from being processed when under the non-met conditional. This is how I see it: preprocessing goes before pragmas handling, so no pragma should made it into further compilation steps from skipped conditional blocks.