### PR TITLE
Fix: macro definitions lookup.

### DIFF
--- a/src/main/z80-compiler/assembly-module.ts
+++ b/src/main/z80-compiler/assembly-module.ts
@@ -142,7 +142,7 @@ export class AssemblyModule implements ISymbolScope {
     if (!this.caseSensitive) {
       name = name.toLowerCase();
     }
-    return !!this.macros[name];
+    return !!this.macros[name] || this.parentModule?.containsMacro(name) === true;
   }
 
   /**
@@ -154,7 +154,7 @@ export class AssemblyModule implements ISymbolScope {
     if (!this.caseSensitive) {
       name = name.toLowerCase();
     }
-    return this.macros[name];
+    return this.macros[name] ?? this.parentModule?.getMacro(name);
   }
 
   /**

--- a/test/assembler/macro-def.test.ts
+++ b/test/assembler/macro-def.test.ts
@@ -226,4 +226,28 @@ describe("Assembler - macro definition", async () => {
       );
     });
   });
+
+  it("macro defined in parent scope", async () => {
+    const compiler = new Z80Assembler();
+    const source = `
+        MyMacro: .macro()
+          nop
+          .endm
+
+        TheModule: .module
+          MyMacro()
+
+          TheInnerModule: .module
+            MyMacro()
+            .endmodule
+
+          .endmodule
+      `;
+
+    const output = await compiler.compile(source);
+
+    expect(output.errorCount).toBe(0);
+    expect(output.containsNestedModule("TheModule")).toBe(true);
+    expect(output.getNestedModule("TheModule").containsNestedModule("TheInnerModule")).toBe(true);
+  });
 });


### PR DESCRIPTION
I thought over this issue after our talk. Indeed, it appeared to be the smallest quirk.

IMO, the fix suggested here provides the most intiutive and straightforward behaviour the user could expect from macros lookup.