### PR TITLE
Refactor save file content

### DIFF
--- a/src/common/utils/DelayedJobs.ts
+++ b/src/common/utils/DelayedJobs.ts
@@ -1,0 +1,70 @@
+export class DelayedJobs {
+  private _delayedJobs = new Map<string, any>();
+
+  public cancel(tag: string): boolean {
+    const job = this._delayedJobs.get(tag);
+    this._delayedJobs.delete(tag);
+    if (!job) return false;
+    clearTimeout(job.timeoutId);
+    job.setCanceled();
+    return true;
+  }
+
+  public instantlyRunAllOf(kind?: number): Promise<any> {
+    const promises = [];
+    const jobs = this.getJobsOfKind(kind);
+    for (const job of jobs) {
+      clearTimeout(job.timeoutId);
+      promises.push(job.setComplete());
+    }
+    return Promise.allSettled(promises);
+  }
+
+  public schedule(
+    delayMs: number,
+    tag: string,
+    kind: number,
+    action: () => Promise<void>
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) =>{
+      this._delayedJobs.get(tag)?.setCanceled();
+
+      const setComplete = async () => {
+        this._delayedJobs.delete(tag);
+        try {
+          await action();
+          resolve();
+        } catch (e) {
+          reject(e);
+          if (e !== "canceled")
+            throw e;
+        }
+      };
+
+      this._delayedJobs.set(
+        tag,
+        {
+          timeoutId: setTimeout(setComplete, delayMs),
+          setCanceled: () => reject("canceled"),
+          setComplete,
+          kind
+        }
+      );
+    });
+  }
+
+  private static filter<T>(it: IterableIterator<T>, p: (T) => boolean) {
+    return {
+      *[Symbol.iterator]() {
+        for (const v of it) {
+          if (p(v)) yield v;
+        }
+      }
+    };
+  }
+
+  private getJobsOfKind(kind?: number): any[] {
+    if (kind === undefined) return [...this._delayedJobs.values()];
+    return [...DelayedJobs.filter(this._delayedJobs.values(), job => job.kind === kind)];
+  }
+}

--- a/src/common/utils/DelayedJobs.ts
+++ b/src/common/utils/DelayedJobs.ts
@@ -10,9 +10,9 @@ export class DelayedJobs {
     return true;
   }
 
-  public instantlyRunAllOf(kind?: number): Promise<any> {
+  public instantlyRunAllOf(kind?: number, tag?: string): Promise<any> {
     const promises = [];
-    const jobs = this.getJobsOfKind(kind);
+    const jobs = this.queryJobsOf(kind, tag);
     for (const job of jobs) {
       clearTimeout(job.timeoutId);
       promises.push(job.setComplete());
@@ -22,8 +22,8 @@ export class DelayedJobs {
 
   public schedule(
     delayMs: number,
-    tag: string,
     kind: number,
+    tag: string,
     action: () => Promise<void>
   ): Promise<void> {
     return new Promise<void>((resolve, reject) =>{
@@ -63,8 +63,14 @@ export class DelayedJobs {
     };
   }
 
-  private getJobsOfKind(kind?: number): any[] {
-    if (kind === undefined) return [...this._delayedJobs.values()];
-    return [...DelayedJobs.filter(this._delayedJobs.values(), job => job.kind === kind)];
+  private queryJobsOf(kind?: number, tag?: string): any[] {
+    if (tag === undefined) {
+      return kind !== undefined ?
+        [...DelayedJobs.filter(this._delayedJobs.values(), job => job.kind === kind)]
+        : [...this._delayedJobs.values()];
+    }
+
+    const job = this._delayedJobs.get(tag);
+    return kind !== undefined && job?.kind === kind || job ? [job] : [];
   }
 }

--- a/src/renderer/abstractions/IProjectService.ts
+++ b/src/renderer/abstractions/IProjectService.ts
@@ -134,7 +134,8 @@ export type IProjectService = {
    * @param file File name
    * @param contents File contents to save
    */
-  saveFileContent(file: string, contents: string | Uint8Array, asYouType?: boolean): Promise<void>;
+  saveFileContent(file: string, contents: string | Uint8Array): Promise<void>;
+  saveFileContentAsYouType(file: string, contents: string | Uint8Array): Promise<void>;
 
   performAllDelayedSavesNow(): Promise<void>;
 

--- a/src/renderer/appIde/DocumentPanels/MonacoEditor.tsx
+++ b/src/renderer/appIde/DocumentPanels/MonacoEditor.tsx
@@ -344,7 +344,7 @@ export const MonacoEditor = ({ document, value, apiLoaded }: EditorProps) => {
 
     // --- Now, save it back to the file
     await projectService
-      .saveFileContent(document.id, document.contents, true)
+      .saveFileContentAsYouType(document.id, document.contents)
       .then(
         () => {
           document.savedVersionCount = document.editVersionCount;

--- a/src/renderer/appIde/services/ProjectService.ts
+++ b/src/renderer/appIde/services/ProjectService.ts
@@ -311,7 +311,7 @@ class ProjectService implements IProjectService {
     contents: string | Uint8Array
   ): Promise<void> {
     const TYPING_DELAY = 1000;
-    return this._delayedJobs.schedule(TYPING_DELAY, file, JOB_KIND_SAVE_FILE,
+    return this._delayedJobs.schedule(TYPING_DELAY, JOB_KIND_SAVE_FILE, file,
       this.saveFileContentInner.bind(this, file, contents))
   }
 

--- a/src/renderer/appIde/services/ProjectService.ts
+++ b/src/renderer/appIde/services/ProjectService.ts
@@ -20,6 +20,9 @@ import {
   incProjectViewStateVersionAction
 } from "@common/state/actions";
 import { documentPanelRegistry } from "@renderer/registry";
+import { DelayedJobs } from "@common/utils/DelayedJobs";
+
+const JOB_KIND_SAVE_FILE = 21;
 
 class ProjectService implements IProjectService {
   private _tree: ITreeView<ProjectNode>;
@@ -40,6 +43,8 @@ class ProjectService implements IProjectService {
   private _docHubServices: IDocumentHubService[] = [];
   private _docHubActivations: IDocumentHubService[] = [];
   private _activeDocHub: IDocumentHubService | undefined;
+
+  private _delayedJobs = new DelayedJobs();
 
   constructor (
     private readonly store: Store<AppState>,
@@ -288,9 +293,6 @@ class ProjectService implements IProjectService {
     return contents ?? (await this.readFileContent(file, isBinary));
   }
 
-  private _onDelayedSavesComplete = new LiteEvent<void>;
-  private _asYouTypeSavesCount = 0;
-
   /**
    * Saves the specified contents of the file to the file system, and then to the cache
    * @param file File name
@@ -298,35 +300,19 @@ class ProjectService implements IProjectService {
    */
   saveFileContent (
     file: string,
-    contents: string | Uint8Array,
-    asYouType?: boolean
+    contents: string | Uint8Array
   ): Promise<void> {
-    if (asYouType) {
-      // -- An average typing speed of 190 chars per minute + 25%.
-      const TYPING_DELAY = 1.25 * 1000 * 60 / 190;
-      return new Promise<void>((resolve, reject) => {
-        ++this._asYouTypeSavesCount;
-        this.scheduleDelayedAction(file, TYPING_DELAY,
-          (canceled: boolean) => {
-            if (canceled) {
-              --this._asYouTypeSavesCount;
-              reject("canceled");
-              return;
-            }
-
-            this.saveFileContentInner(file, contents)
-              .then(resolve, reject)
-              .finally(() => {
-                if (--this._asYouTypeSavesCount <= 0) {
-                  this._onDelayedSavesComplete.fire();
-                  this._onDelayedSavesComplete.release();
-                }
-              });
-          })
-      });
-    }
-    this.cancelDelayedAction(file);
+    this._delayedJobs.cancel(file);
     return this.saveFileContentInner(file, contents);
+  }
+
+  saveFileContentAsYouType (
+    file: string,
+    contents: string | Uint8Array
+  ): Promise<void> {
+    const TYPING_DELAY = 1000;
+    return this._delayedJobs.schedule(TYPING_DELAY, file, JOB_KIND_SAVE_FILE,
+      this.saveFileContentInner.bind(this, file, contents))
   }
 
   private async saveFileContentInner(
@@ -358,12 +344,7 @@ class ProjectService implements IProjectService {
   }
 
   performAllDelayedSavesNow(): Promise<void> {
-    return this._asYouTypeSavesCount > 0 ?
-      new Promise<void>((resolve, _) => {
-        this._onDelayedSavesComplete.on(resolve);
-        this.runAllDelayedActionsInstantly();
-      })
-      : Promise.resolve();
+    return this._delayedJobs.instantlyRunAllOf(JOB_KIND_SAVE_FILE);
   }
 
   /**
@@ -561,62 +542,6 @@ class ProjectService implements IProjectService {
 
   private signDocServiceVersionChanged (hubId: number): void {
     this.store.dispatch(incDocHubServiceVersionAction(hubId), "ide");
-  }
-
-  private _delayedActions = new Map<string, any>();
-
-  private cancelDelayedAction(tag: string): void {
-    const job = this._delayedActions.get(tag);
-    if (!job) return;
-    this._delayedActions.delete(tag);
-
-    clearTimeout(job.timeoutId);
-    try {
-      job.action(true);
-    } catch (e) {
-      reportError(e);
-    }
-  }
-
-  private runAllDelayedActionsInstantly(): void {
-    const jobs = [...this._delayedActions.values()];
-    this._delayedActions.clear();
-    for (const job of jobs) {
-      clearTimeout(job.timeoutId);
-      try {
-        job.action(false);
-      } catch (e) {
-        reportError(e);
-      }
-    }
-  }
-
-  private scheduleDelayedAction(
-    tag: string,
-    delayMs: number,
-    action: (canceled: boolean) => void
-  ): void {
-    const job = this._delayedActions.get(tag);
-    if (job) {
-      clearTimeout(job.timeoutId);
-      try {
-        job.action(true);
-      } catch (e) {
-        reportError(e);
-      }
-    }
-
-    this._delayedActions.set(
-      tag,
-      {
-        timeoutId: setTimeout(() => {
-          if (this._delayedActions.delete(tag)) {
-            action(false);
-          }
-        }, delayMs),
-        action
-      }
-    );
   }
 }
 


### PR DESCRIPTION
This is a re-factoring attempt as we discussed, including a little update to the recent 'save-on-exit' logic.

I have tested the three cases of how user may quit an application:
- File -> Exit
- Close all windows at the Windows task bar context menu
- Closing the Emu with sysmenu button.

There is the interactive Exit command, which makes the app.quit() call, so let's treat it the same as the File -> Exit case.