### PR TITLE
Restrict all the features that don't make sense when the open folder is not a Klive project.

### DIFF
--- a/src/renderer/appIde/SiteBarPanels/ExplorerPanel.tsx
+++ b/src/renderer/appIde/SiteBarPanels/ExplorerPanel.tsx
@@ -111,6 +111,8 @@ const ExplorerPanel = () => {
     vlApi.current.refresh();
   };
 
+  const [forceRefresh, setForceRefresh] = useState(0);
+
   // --- Let's use this context menu when clicking a project tree node
   const [contextMenuState, contextMenuApi] = useContextMenuState();
   const contextMenu = (
@@ -118,6 +120,17 @@ const ExplorerPanel = () => {
       state={contextMenuState}
       onClickAway={contextMenuApi.conceal}
     >
+      {selectedNodeIsRoot && (
+        <>
+          <ContextMenuItem
+            text='Refresh'
+            clicked={()=> {
+              folderCache.clear();
+              setForceRefresh(forceRefresh + 1);
+            }}
+          />
+        </>
+      )}
       {selectedContextNodeIsFolder && (
         <>
           <ContextMenuItem
@@ -168,7 +181,7 @@ const ExplorerPanel = () => {
       />
       <ContextMenuItem
         text='Exclude'
-        disabled={selectedNodeIsProjectFile || selectedNodeIsRoot}
+        disabled={selectedNodeIsProjectFile || selectedNodeIsRoot || !isKliveProject}
         clicked={async () => {
           await ideCommandsService.executeCommand(
             `p:x "${selectedContextNode.data.fullPath}"`
@@ -199,6 +212,7 @@ const ExplorerPanel = () => {
               );
               await saveProject(messenger);
             }}
+            disabled={!isKliveProject}
           />
         </>
       )}
@@ -564,7 +578,7 @@ const ExplorerPanel = () => {
         folderCache.set(folderPath, projectTree);
       }
     })();
-  }, [folderPath, excludedItems]);
+  }, [folderPath, excludedItems, forceRefresh]);
 
   // --- Render the Explorer panel
   return folderPath ? (

--- a/src/renderer/controls/Toolbar.tsx
+++ b/src/renderer/controls/Toolbar.tsx
@@ -72,13 +72,13 @@ export const Toolbar = ({ ide, kliveProjectLoaded }: Props) => {
   const muted = useSelector(s => s.emulatorState?.soundMuted ?? false);
   const fastLoad = useSelector(s => s.emulatorState?.fastLoad ?? false);
   const isDebugging = useSelector(s => s.emulatorState?.isDebugging ?? false);
-  const isKliveProject = useSelector(s => s.project?.isKliveProject ?? false);
   const isCompiling = useSelector(s => s.compilation?.inProgress ?? false);
   const isRunning =
     state !== MachineControllerState.None &&
     state !== MachineControllerState.Stopped;
-  const canStart = !isCompiling && !isRunning;
-  const mayInjectCode = ide && isKliveProject;
+  const canStart = (!ide || kliveProjectLoaded) && !isCompiling && !isRunning;
+  const canPickStartOption = (!ide || kliveProjectLoaded) && !isRunning;
+  const mayInjectCode = ide && kliveProjectLoaded;
   const [ startMode, setStartMode ] = useState(ide && kliveProjectLoaded ? "debug" : "start");
 
   const storeDispatch = useDispatch();
@@ -132,7 +132,7 @@ export const Toolbar = ({ ide, kliveProjectLoaded }: Props) => {
       />
       <div
           className={styles.toolbarDropdownContainer}
-          style={isRunning ? { pointerEvents: 'none', opacity: '.4' } : {}}>
+          style={!canPickStartOption ? { pointerEvents: 'none', opacity: '.4' } : {}}>
         <Dropdown
           placeholder={undefined}
           options={[...startOptions]}
@@ -208,7 +208,7 @@ export const Toolbar = ({ ide, kliveProjectLoaded }: Props) => {
           var response: any;
           switch (restartTarget) {
             case 'project': {
-              if (isKliveProject) {
+              if (kliveProjectLoaded) {
                 messenger.postMessage({
                   type: "IdeExecuteCommand",
                   commandText: "outp build"
@@ -373,7 +373,7 @@ export const Toolbar = ({ ide, kliveProjectLoaded }: Props) => {
             selected={syncSourceBps}
             fill='orange'
             title='Stop sync with current source code breakpoint'
-            enable={isKliveProject}
+            enable={kliveProjectLoaded}
             clicked={() => {
               dispatch(syncSourceBreakpointsAction(!syncSourceBps));
             }}


### PR DESCRIPTION
In addition, 'Refresh' context menu item is added at the root folder tree entry.