### PR TITLE
Z88 UV Eprom emulation implemented

### DIFF
--- a/src/emu/machines/z88/Z88BlinkDevice.ts
+++ b/src/emu/machines/z88/Z88BlinkDevice.ts
@@ -357,7 +357,7 @@ export class Z88BlinkDevice implements IZ88BlinkDevice, IZ88BlinkTestDevice {
   }
 
   /**
-   * Sets the TCOM register value
+   * Sets the COM register value
    * @param value value to set
    */
   setCOM (value: number): void {

--- a/src/emu/machines/z88/Z88Machine.ts
+++ b/src/emu/machines/z88/Z88Machine.ts
@@ -21,6 +21,7 @@ import { MC_SCREEN_SIZE } from "@common/machines/constants";
 import { MC_Z88_INTROM } from "@common/machines/constants";
 import { Z88BankedMemory } from "./memory/Z88BankedMemory";
 import { Z88RomMemoryCard } from "./memory/Z88RomMemoryCard";
+import { Z88UvEpromMemoryCard } from "./memory/Z88UvEpromMemoryCard";
 
 // --- Default ROM file
 const DEFAULT_ROM = "z88v50-r1f99aaae";
@@ -165,6 +166,10 @@ export class Z88Machine extends Z80MachineBase implements IZ88Machine {
     // --- Initialize the Z88 machine's default ROM
     const romCard = new Z88RomMemoryCard(this, romContents.length);
     this.memory.insertCard(0, romCard, romContents);
+
+    // --- Insert 128K Eprom card in slot 3 (reset to FFh)
+    const uvepr128k = new Z88UvEpromMemoryCard(this, 0x02_0000);
+    this.memory.insertCard(3, uvepr128k);
   }
 
   /**
@@ -352,7 +357,6 @@ export class Z88Machine extends Z80MachineBase implements IZ88Machine {
    */
   doWritePort (port: number, value: number): void {
     const addr8 = port & 0xff;
-
     // --- No ports below address 0x70 are handled
     if (addr8 < 0x70) {
       return;
@@ -408,7 +412,7 @@ export class Z88Machine extends Z80MachineBase implements IZ88Machine {
         blink.setINT(value);
         return;
 
-      case 0xb2:
+      case 0xb3:
         blink.EPR = value;
         return;
 

--- a/src/emu/machines/z88/memory/Z88UvEpromMemoryCard.ts
+++ b/src/emu/machines/z88/memory/Z88UvEpromMemoryCard.ts
@@ -65,11 +65,10 @@ export class Z88UvEpromMemoryCard extends Z88MemoryCardBase {
     }
 
     if (
-      (blinkCom & COMFlags.LCDON) == 0 &&
       (blinkCom & COMFlags.VPPON) != 0 &&
       ((blinkCom & COMFlags.PROGRAM) != 0 || (blinkCom & COMFlags.OVERP) != 0)
     ) {
-      // We're somwhere in slot 3, LCD turned off, VPP enabled and either programming or overprogramming enabled
+      // We're somwhere in slot 3, VPP enabled and either programming or overprogramming enabled
 
       switch (this.type) {
         case CardType.EpromVpp32KB:

--- a/src/emu/machines/z88/memory/Z88UvEpromMemoryCard.ts
+++ b/src/emu/machines/z88/memory/Z88UvEpromMemoryCard.ts
@@ -100,16 +100,13 @@ export class Z88UvEpromMemoryCard extends Z88MemoryCardBase {
    */
   onInserted (memOffset: number): void {
     this.memOffset = memOffset;
-
-    // TODO: Init the card after insertion
     this.setPristineState();
   }
 
   /**
-   * Sets the card to its pristine state
+   * Sets the UV Eprom card to it's pristine state (FFh)
    */
   setPristineState (): void {
-    // TODO: Change it to the pristine state
     for (let i = 0; i < this.size; i++) {
       this.host.memory.memory[this.memOffset + i] = 0xff;
     }

--- a/test/z88/memory-eprom-io.test.ts
+++ b/test/z88/memory-eprom-io.test.ts
@@ -5,49 +5,63 @@ import { Z88TestMachine } from "./Z88TestMachine";
 import { Z88UvEpromMemoryCard } from "@emu/machines/z88/memory/Z88UvEpromMemoryCard";
 import { COMFlags } from "@emu/machines/z88/IZ88BlinkDevice";
 
+const addr32K: number[] = [
+  // logical addresses for SR2, SR3 (32K range)
+  0x8000, 0x89ab, 0x9fff, 0xa000, 0xbcde, 0xbfff, 0xc000, 0xcdef, 0xdfff
+];
+const addrSR3: number[] = [
+  // logical addresses for SR3 (16K range)
+  0xc000, 0xc001, 0xcdef, 0xdfff, 0xefff, 0xfffe, 0xffff
+];
+
 describe("Z88 - UV EPROM Card Read / Blow bytes", function () {
-
-  const addr32K: number[] = [
-    // logical addresses for SR2, SR3 (32K range)
-    0x8000, 0x89ab, 0x9fff, 0xa000, 0xbcde, 0xbfff, 0xc000, 0xcdef, 0xdfff
-  ];
-  const addrSR3: number[] = [
-    // logical addresses for SR3 (16K range)
-    0xc000, 0xc001, 0xcdef, 0xdfff, 0xefff, 0xfffe, 0xffff
-  ];
-
-  // --- Create the machine
-  const m = new Z88TestMachine();
-  const mem = m.memory;
-  const memt = mem as IZ88BankedMemoryTestSupport;
-
-  // --- Create 32K UV Eprom Card
-  const uvepr32k = new Z88UvEpromMemoryCard(m, 0x00_8000);
-  // --- Insert 32K Eprom card in slot 3 (reset to FFh)
-  mem.insertCard(3, uvepr32k);
-
-  // bind top-two banks of slot 3 into logical address space
-  m.blinkDevice.setSR2(0xfe);
-  m.blinkDevice.setSR3(0xff);
-
   addr32K.forEach(addr => {
     it(`32K EPROM read pristine content (${addr})`, () => {
+      // --- Create the machine
+      const m = new Z88TestMachine();
+      const mem = m.memory;
+      const memt = mem as IZ88BankedMemoryTestSupport;
+
+      // --- Create 32K UV Eprom Card
+      const uvepr32k = new Z88UvEpromMemoryCard(m, 0x00_8000);
+      // --- Insert 32K Eprom card in slot 3 (reset to FFh)
+      mem.insertCard(3, uvepr32k);
+
+      // bind top-two banks of slot 3 into logical address space
+      m.blinkDevice.setSR2(0xfe);
+      m.blinkDevice.setSR3(0xff);
+
       const value = m.memory.readMemory(addr);
       expect(value).toBe(0xff);
     });
   });
 
-  // define PROGRAM & OVERP characteristics for 32K UV EPROM
-  m.blinkDevice.EPR = 0x48;
-
   addr32K.forEach(addr => {
     it(`32K EPROM blow content (${addr})`, () => {
+      // --- Create the machine
+      const m = new Z88TestMachine();
+      const mem = m.memory;
+      const memt = mem as IZ88BankedMemoryTestSupport;
+
+      // --- Create 32K UV Eprom Card
+      const uvepr32k = new Z88UvEpromMemoryCard(m, 0x00_8000);
+      // --- Insert 32K Eprom card in slot 3 (reset to FFh)
+      mem.insertCard(3, uvepr32k);
+
+      // bind top-two banks of slot 3 into logical address space
+      m.blinkDevice.setSR2(0xfe);
+      m.blinkDevice.setSR3(0xff);
+
       // blowing 0 bits (from 1)...
       // (on real H/W, more than 70 iterations of PROGRAM and OVERP are done.
       //  here, we simply test that conditions are met, once)
 
       // switch LCD off and VPP pin ON, then UV Eprom PROGRAM
       m.blinkDevice.setCOM(COMFlags.VPPON | COMFlags.PROGRAM);
+
+      // define PROGRAM & OVERP characteristics for 32K UV EPROM
+      m.blinkDevice.EPR = 0x48;
+
       m.memory.writeMemory(addr, 0xf0);
       const valuePROGRAM = m.memory.readMemory(addr);
       expect(valuePROGRAM).toBe(0xf0);
@@ -60,26 +74,27 @@ describe("Z88 - UV EPROM Card Read / Blow bytes", function () {
     });
   });
 
-  // test completed for 32K UV Eprom
-  mem.removeCard(3);
-
-  // define PROGRAM & OVERP characteristics for 128K(256K) type UV EPROM
-  m.blinkDevice.EPR = 0x69;
-
-  // --- Create 128K UV Eprom Card
-  const uvepr128k = new Z88UvEpromMemoryCard(m, 0x02_0000);
-  // --- Insert 128K Eprom card in slot 3 (reset to FFh)
-  mem.insertCard(3, uvepr128k);
-
   // begin tests from bottom of slot 3 of 128K card (8 x 16K), upwards
-  for (let bnk128K = 0xc0; bnk128K<=0xc8; bnk128K++) {
-    m.blinkDevice.setSR3(bnk128K);
+  for (let bnk128K = 0xc0; bnk128K <= 0xc8; bnk128K++) {
     addrSR3.forEach(addr => {
       it(`128K EPROM (Bank ${bnk128K}) read pristine content (${addr})`, () => {
+        // --- Create the machine
+        const m = new Z88TestMachine();
+        const mem = m.memory;
+        const memt = mem as IZ88BankedMemoryTestSupport;
+
+        // --- Create 128K UV Eprom Card
+        const uvepr128k = new Z88UvEpromMemoryCard(m, 0x02_0000);
+        // --- Insert 128K Eprom card in slot 3 (reset to FFh)
+        mem.insertCard(3, uvepr128k);
+
+        // define PROGRAM & OVERP characteristics for 128K(256K) type UV EPROM
+        m.blinkDevice.EPR = 0x69;
+
+        m.blinkDevice.setSR3(bnk128K);
         const value = m.memory.readMemory(addr);
         expect(value).toBe(0xff);
       });
     });
   }
-
 });

--- a/test/z88/memory-eprom-io.test.ts
+++ b/test/z88/memory-eprom-io.test.ts
@@ -4,30 +4,34 @@ import { IZ88BankedMemoryTestSupport } from "@emu/machines/z88/memory/Z88BankedM
 import { Z88TestMachine } from "./Z88TestMachine";
 import { Z88UvEpromMemoryCard } from "@emu/machines/z88/memory/Z88UvEpromMemoryCard";
 
-describe("Z88 - Memory read (32K EPROM)", function () {
+describe("Z88 - UV EPROM Card Read / Blow bytes", function () {
 
-  const addresses: number[] = [
-    // logical addresses for SR2, SR3
+  const addr32K: number[] = [
+    // logical addresses for SR2, SR3 (32K range)
     0x8000, 0x89ab, 0x9fff, 0xa000, 0xbcde, 0xbfff, 0xc000, 0xcdef, 0xdfff
   ];
+  const addrSR3: number[] = [
+    // logical addresses for SR3 (16K range)
+    0xc000, 0xc001, 0xcdef, 0xdfff, 0xefff, 0xfffe, 0xffff
+  ];
 
-  addresses.forEach(addr => {
-    it(`EPROM read (${addr}) after init`, () => {
-      // --- Create the machine
-      const m = new Z88TestMachine();
+  // --- Create the machine
+  const m = new Z88TestMachine();
 
-      // --- Create 32K UV Eprom Card
-      const uvepr32k = new Z88UvEpromMemoryCard(m, 0x00_8000);
+  // --- Create 32K UV Eprom Card
+  const uvepr32k = new Z88UvEpromMemoryCard(m, 0x00_8000);
 
-      const mem = m.memory;
-      const memt = mem as IZ88BankedMemoryTestSupport;
+  const mem = m.memory;
+  const memt = mem as IZ88BankedMemoryTestSupport;
 
-      // --- Insert 32K Eprom card in slot 3
-      mem.insertCard(3, uvepr32k);
-      // bind top-two banks of slot 3 into logical address space
-      m.blinkDevice.setSR2(0xfe);
-      m.blinkDevice.setSR3(0xff);
+  // --- Insert 32K Eprom card in slot 3 (reset to FFh)
+  mem.insertCard(3, uvepr32k);
+  // bind top-two banks of slot 3 into logical address space
+  m.blinkDevice.setSR2(0xfe);
+  m.blinkDevice.setSR3(0xff);
 
+  addr32K.forEach(addr => {
+    it(`32K EPROM read pristine content (${addr})`, () => {
       const value = m.memory.readMemory(addr);
       expect(value).toBe(0xff);
     });

--- a/test/z88/memory-eprom-io.test.ts
+++ b/test/z88/memory-eprom-io.test.ts
@@ -18,15 +18,14 @@ describe("Z88 - UV EPROM Card Read / Blow bytes", function () {
 
   // --- Create the machine
   const m = new Z88TestMachine();
-
-  // --- Create 32K UV Eprom Card
-  const uvepr32k = new Z88UvEpromMemoryCard(m, 0x00_8000);
-
   const mem = m.memory;
   const memt = mem as IZ88BankedMemoryTestSupport;
 
+  // --- Create 32K UV Eprom Card
+  const uvepr32k = new Z88UvEpromMemoryCard(m, 0x00_8000);
   // --- Insert 32K Eprom card in slot 3 (reset to FFh)
   mem.insertCard(3, uvepr32k);
+
   // bind top-two banks of slot 3 into logical address space
   m.blinkDevice.setSR2(0xfe);
   m.blinkDevice.setSR3(0xff);
@@ -61,6 +60,26 @@ describe("Z88 - UV EPROM Card Read / Blow bytes", function () {
     });
   });
 
-  // TO DO : read test cases for UV Eprom 128K
-  // const uvepr128k = new Z88UvEpromMemoryCard(m, 0x02_0000);
+  // test completed for 32K UV Eprom
+  mem.removeCard(3);
+
+  // define PROGRAM & OVERP characteristics for 128K(256K) type UV EPROM
+  m.blinkDevice.EPR = 0x69;
+
+  // --- Create 128K UV Eprom Card
+  const uvepr128k = new Z88UvEpromMemoryCard(m, 0x02_0000);
+  // --- Insert 128K Eprom card in slot 3 (reset to FFh)
+  mem.insertCard(3, uvepr128k);
+
+  // begin tests from bottom of slot 3 of 128K card (8 x 16K), upwards
+  for (let bnk128K = 0xc0; bnk128K<=0xc8; bnk128K++) {
+    m.blinkDevice.setSR3(bnk128K);
+    addrSR3.forEach(addr => {
+      it(`128K EPROM (Bank ${bnk128K}) read pristine content (${addr})`, () => {
+        const value = m.memory.readMemory(addr);
+        expect(value).toBe(0xff);
+      });
+    });
+  }
+
 });

--- a/test/z88/memory-eprom-io.test.ts
+++ b/test/z88/memory-eprom-io.test.ts
@@ -3,6 +3,7 @@ import { expect } from "expect";
 import { IZ88BankedMemoryTestSupport } from "@emu/machines/z88/memory/Z88BankedMemory";
 import { Z88TestMachine } from "./Z88TestMachine";
 import { Z88UvEpromMemoryCard } from "@emu/machines/z88/memory/Z88UvEpromMemoryCard";
+import { COMFlags } from "@emu/machines/z88/IZ88BlinkDevice";
 
 describe("Z88 - UV EPROM Card Read / Blow bytes", function () {
 
@@ -34,6 +35,29 @@ describe("Z88 - UV EPROM Card Read / Blow bytes", function () {
     it(`32K EPROM read pristine content (${addr})`, () => {
       const value = m.memory.readMemory(addr);
       expect(value).toBe(0xff);
+    });
+  });
+
+  // define PROGRAM & OVERP characteristics for 32K UV EPROM
+  m.blinkDevice.EPR = 0x48;
+
+  addr32K.forEach(addr => {
+    it(`32K EPROM blow content (${addr})`, () => {
+      // blowing 0 bits (from 1)...
+      // (on real H/W, more than 70 iterations of PROGRAM and OVERP are done.
+      //  here, we simply test that conditions are met, once)
+
+      // switch LCD off and VPP pin ON, then UV Eprom PROGRAM
+      m.blinkDevice.setCOM(COMFlags.VPPON | COMFlags.PROGRAM);
+      m.memory.writeMemory(addr, 0xf0);
+      const valuePROGRAM = m.memory.readMemory(addr);
+      expect(valuePROGRAM).toBe(0xf0);
+
+      // switch LCD off and VPP pin ON, then UV Eprom OVERP
+      m.blinkDevice.setCOM(COMFlags.VPPON | COMFlags.OVERP);
+      m.memory.writeMemory(addr, 0x0f);
+      const valueOVERP = m.memory.readMemory(addr);
+      expect(valueOVERP).toBe(0x00);
     });
   });
 


### PR DESCRIPTION
Bugfix in Z88Machine::doWritePort(): EPR register is B3h!
Test cases for 32K + 128K Eproms implemented.
Checked that OZ ROMs v4.0 and v4.7 can create File Cards when empty 32K or large UV Eproms are available in slot 3.