### PR TITLE
Fixed Z88 Italian KB not being part of supported list of layouts

### DIFF
--- a/src/emu/machines/z88/Z88Machine.ts
+++ b/src/emu/machines/z88/Z88Machine.ts
@@ -206,7 +206,7 @@ export class Z88Machine extends Z80MachineBase implements IZ88Machine {
 
       // --- Set up the default keyboard layout
       let keyboardLayout = this.config?.[MC_Z88_KEYBOARD] ?? "uk";
-      const supported = ["uk", "de", "fr", "es", "dk", "se"];
+      const supported = ["uk", "de", "fr", "es", "it", "dk", "se"];
       if (supported.indexOf(keyboardLayout) < 0) {
         keyboardLayout = "uk";
       }


### PR DESCRIPTION
The little detail slipped through. Now, IT KB is correctly selected, when selecting Z88 Italian legacy ROM.