### PR TITLE
fix(deps): repair CI - lockfile sync and monaco-editor 0.56 imports

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,15 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/react-dom"
         update-types: ["version-update:semver-major"]
+      # monaco-editor 0.56 reorganized the ESM entry points: the package now has an
+      # "exports" map that maps "./*" to "./esm/vs/*.js", so every existing
+      # "monaco-editor/esm/vs/..." deep import stops resolving, and the language
+      # contributions and workers move to new "monaco-editor/features/..." and
+      # "monaco-editor/languages/..." register entry points. Revisit when the
+      # monacoBootstrap/worker wiring has been migrated to those entry points.
+      # Patch updates within 0.55.x are still allowed.
+      - dependency-name: "monaco-editor"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
 
   - package-ecosystem: npm
     directory: /docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "expect": "^30.5.0",
         "jsdom": "^30.0.1",
         "lodash": "^4.18.1",
-        "monaco-editor": "^0.56.0",
+        "monaco-editor": "^0.55.1",
         "prettier": "^3.9.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -8379,13 +8379,13 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
-      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "dompurify": "3.4.8",
+        "dompurify": "3.2.7",
         "marked": "14.0.0"
       }
     },
@@ -16525,9 +16525,9 @@
       }
     },
     "monaco-editor": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
-      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "dev": true,
       "requires": {
         "dompurify": "^3.4.14",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "expect": "^30.5.0",
     "jsdom": "^30.0.1",
     "lodash": "^4.18.1",
-    "monaco-editor": "^0.56.0",
+    "monaco-editor": "^0.55.1",
     "prettier": "^3.9.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -116,7 +116,10 @@
   "overrides": {
     "postcss": "^8.5.26",
     "dompurify": "^3.4.14",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "tsconfck": {
+      "typescript": "$typescript"
+    }
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",


### PR DESCRIPTION
Both workflows on `master` are red. Two independent causes, the second hidden behind the first.

- [Test / unit](https://github.com/Dotneteer/kliveide/actions/runs/33739245983/job/100597021924)
- [GitHub Pages deploy / build](https://github.com/Dotneteer/kliveide/actions/runs/33739245929/job/100597022193)

## 1. Root `npm ci` fails — lockfile permanently out of sync

Both jobs died at their install step:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: typescript@5.9.3 from lock file
```

The root `typescript` is `^6.0.2`, but `vite-tsconfig-paths` → `tsconfck` declares an **optional peer** `typescript: ^5.0.0`. TypeScript 6 does not satisfy it, so npm has to materialize a nested `typescript@5.9.3` under `vite-tsconfig-paths`.

#1307 regenerated the lock with that node present. Every Dependabot lock regeneration since (#1308 onward) dropped it again — so `package.json` and the lockfile have been out of sync ever since, and will keep drifting:

| lockfile commit | has `vite-tsconfig-paths/node_modules/typescript` |
| --- | --- |
| #1307 (CI repair) | ✅ |
| #1308 … #1317 (Dependabot) | ❌ |

Simply regenerating the lock papers over this until the next Dependabot merge. Instead, an npm `override` points tsconfck's `typescript` peer at the root `typescript`, so **no nested node is ever needed and both resolvers agree**:

```json
"tsconfck": { "typescript": "$typescript" }
```

This required **zero lockfile changes** — master's committed lock is already byte for byte what npm produces with the override in place (`cmp` clean).

The override is inert in practice: tsconfck only imports typescript from its `parseNative`/`findNative` paths, `vite-tsconfig-paths` only reaches those when the `parseNative` option is set, and nothing in this repo uses the plugin at all. (The `tsconfig-paths` package used by `scripts/benchmark-zxnext-wasm.cjs` is a different, unrelated package.)

## 2. monaco-editor 0.56 breaks every deep ESM import

With the install fixed, the unit job then failed on three test files:

```
Error: Failed to resolve import "monaco-editor/esm/vs/editor/editor.api"
from "src/renderer/appIde/project/ksxLanguageProvider.ts". Does the file exist?
```

#1316 bumped monaco-editor 0.55.1 → 0.56.0. Per its changelog, 0.56 is a **documented breaking reorganization of the ESM entry points**. The package now ships an `exports` map:

```json
"exports": { ".": {...}, "./*.js": "./esm/vs/*.js", "./*": "./esm/vs/*.js" }
```

so `monaco-editor/esm/vs/editor/editor.api` now resolves to `./esm/vs/esm/vs/editor/editor.api.js` — which does not exist. The language contributions and workers also move to new `monaco-editor/features/…` and `monaco-editor/languages/…` register entry points.

That migration touches `monacoBootstrap.ts`, all five worker imports, `CustomLanguageInfo.ts` and `ksxLanguageProvider.ts`, and needs verification in the running renderer (editor, workers, custom Z80/KSX languages, themes) — too much to fold into a CI repair. Pinned back to `^0.55.1` with a documented Dependabot ignore for minor and major bumps; **0.55.x patches still flow**.

## Verification

All run locally from a clean `npm ci`:

| check | result |
| --- | --- |
| `npm ci` (root) | ✅ lockfile untouched afterwards |
| `npm run build:check` (tsc) | ✅ clean |
| `npm run check:sp48-wasm-size` | ✅ 200272 / 510000 bytes |
| `npm run test:unit` | ✅ 18938 passed, 119 skipped, 564 files |
| `npm run doc:install` | ✅ |
| `npm run doc:build` | ✅ 86 pages indexed |
| `npm run doc:check` | ✅ 89 routes, 102 assets, 11517 links, all six Z80 token colours |

## Follow-ups (not in this PR)

- Migrate the Monaco wiring to the 0.56 entry points, then lift the Dependabot ignore.
- `vite-tsconfig-paths` appears to be an entirely unused devDependency — removing it would delete this failure mode at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)